### PR TITLE
 Minimal 64x4 Redux support, byte-wise char equality, and long hex literalsRedux

### DIFF
--- a/.github/workflows/release-intel-hex.yml
+++ b/.github/workflows/release-intel-hex.yml
@@ -32,8 +32,11 @@ jobs:
           set -euo pipefail
 
           cfg="$(skills/compile-min-64x4/scripts/fetch_min64x4_config.sh)"
+          redux_cfg="$(skills/compile-min-64x4/scripts/fetch_min64x4_config.sh --redux)"
           asset_name="extended-min.${RELEASE_TAG}.hex"
           acc_asset_name="extended-min-acc.${RELEASE_TAG}.hex"
+          redux_asset_name="extended-min-redux.${RELEASE_TAG}.hex"
+          redux_acc_asset_name="extended-min-redux-acc.${RELEASE_TAG}.hex"
 
           bespokeasm compile \
             -c "$cfg" \
@@ -50,10 +53,29 @@ jobs:
             -D USE_ACCELERATOR \
             extended-min.min64x4 >"$acc_asset_name"
 
+          bespokeasm compile \
+            -c "$redux_cfg" \
+            -n \
+            -p \
+            -t intel_hex \
+            extended-min.min64x4r >"$redux_asset_name"
+
+          bespokeasm compile \
+            -c "$redux_cfg" \
+            -n \
+            -p \
+            -t intel_hex \
+            -D USE_ACCELERATOR \
+            extended-min.min64x4r >"$redux_acc_asset_name"
+
           test -s "$asset_name"
           test -s "$acc_asset_name"
+          test -s "$redux_asset_name"
+          test -s "$redux_acc_asset_name"
           echo "asset_path=$PWD/$asset_name" >> "$GITHUB_OUTPUT"
           echo "acc_asset_path=$PWD/$acc_asset_name" >> "$GITHUB_OUTPUT"
+          echo "redux_asset_path=$PWD/$redux_asset_name" >> "$GITHUB_OUTPUT"
+          echo "redux_acc_asset_path=$PWD/$redux_acc_asset_name" >> "$GITHUB_OUTPUT"
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
@@ -61,3 +83,5 @@ jobs:
           files: |
             ${{ steps.build.outputs.asset_path }}
             ${{ steps.build.outputs.acc_asset_path }}
+            ${{ steps.build.outputs.redux_asset_path }}
+            ${{ steps.build.outputs.redux_acc_asset_path }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ The main source files are:
 The two source files are kept in sync line-for-line. The only intended differences are:
 
 - the Redux renames the A-store instruction family: `STZ/STT/STB/STR/STS` (original) is `SDZ/SDT/SDB/SDR/SDS` (Redux). On the Redux, `STZ` and `STT` still exist but are *two-operand subtraction instructions* — a missed rename fails to assemble because the operand counts do not match.
-- a handful of fast-vs-long branch form differences. The Redux resolves a fast branch's target page from the *instruction* address; the original resolves it from the *operand fetch* address. They disagree only when a fast-branch opcode sits at the last byte of a page (`0xXXFF`), and the extra long-branch bytes shift downstream layout, which can cascade. BespokeASM enforces the correct rule for each ISA at compile time.
+- a handful of fast-vs-long branch form differences. Both machines resolve a fast branch's target page from the *operand fetch* address, but the two files' layouts differ slightly (renames, pragmas), so different branches land near page edges in each; the extra long-branch bytes shift downstream layout, which can cascade. BespokeASM enforces the page rule at compile time.
+- On both machines the fast-op target page resolves from the *operand fetch* position, so a fast op whose opcode sits at the last byte of a page targets the *next* page. The BespokeASM configs enforce this (`match_on_argument_bytcode: true` on `address_lsb`); the Redux config was missing that flag until 2026-07-10 (symptom on hardware: corrupted tokenization, nonsense early errors like `Invalid expr` on a plain constant). If such symptoms appear after a layout change, verify the fetched config has the flag before debugging the interpreter.
 - the `#require __LANGUAGE_NAME__` / `__LANGUAGE_VERSION__` pragmas and the file header.
 
 Rules:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,26 @@
 # Extended Min Agent Guide
 
-This directory contains the `Extended Min` interpreter for the Minimal 64x4 TTL computer.
+This directory contains the `Extended Min` interpreter for the Minimal 64x4 TTL computer and its improved variant, the Minimal 64x4 Redux.
 
-The main source file is:
+The main source files are:
 
-- `extended-min.min64x4`
+- `extended-min.min64x4`: targets the original Minimal 64x4
+- `extended-min.min64x4r`: targets the Minimal 64x4 Redux
+
+## Dual-Target Sync Rules
+
+The two source files are kept in sync line-for-line. The only intended differences are:
+
+- the Redux renames the A-store instruction family: `STZ/STT/STB/STR/STS` (original) is `SDZ/SDT/SDB/SDR/SDS` (Redux). On the Redux, `STZ` and `STT` still exist but are *two-operand subtraction instructions* — a missed rename fails to assemble because the operand counts do not match.
+- a handful of fast-vs-long branch form differences. The Redux resolves a fast branch's target page from the *instruction* address; the original resolves it from the *operand fetch* address. They disagree only when a fast-branch opcode sits at the last byte of a page (`0xXXFF`), and the extra long-branch bytes shift downstream layout, which can cascade. BespokeASM enforces the correct rule for each ISA at compile time.
+- the `#require __LANGUAGE_NAME__` / `__LANGUAGE_VERSION__` pragmas and the file header.
+
+Rules:
+
+- apply every functional change to both files
+- write new code so it is correct on both machines (see the A register caveat below for the Redux difference in `CIT`/`CIB`/`CIZ`)
+- compile all four builds after meaningful changes: default and `USE_ACCELERATOR` for each target
+- do not assume a fast branch valid in one file is valid in the other; let the assembler decide and convert to the long form where needed
 
 The architecture and language behavior are described in:
 
@@ -31,7 +47,8 @@ This is not a small library. Most changes affect multiple phases of the interpre
 
 ## Key Directories
 
-- `extended-min.min64x4`: the interpreter implementation
+- `extended-min.min64x4`: the interpreter implementation (Minimal 64x4)
+- `extended-min.min64x4r`: the interpreter implementation (Minimal 64x4 Redux)
 - `ARCHITECTURE.md`: required reference for runtime structure and memory model
 - `lib/`: Min/XMin helper libraries used by interpreted programs
 - `software/`: sample programs
@@ -74,19 +91,21 @@ bespokeasm compile -c /path/to/slu4-minimal-64x4.yaml -n -p -t intel_hex -D USE_
 
 If available, use the local compile helper workflow instead of hand-rolling commands.
 
-Repo-local compile helper:
+Repo-local compile helper (the source extension selects the instruction-set config):
 
 ```bash
 skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4
 skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4 -- -D USE_ACCELERATOR
+skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4r
+skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4r -- -D USE_ACCELERATOR
 ```
 
-That helper fetches the Minimal 64x4 BespokeASM config from the BespokeASM GitHub repo into `/tmp` and avoids depending on host-specific absolute paths.
+That helper fetches the matching Minimal 64x4 or Minimal 64x4 Redux BespokeASM config from the BespokeASM GitHub repo into `/tmp` and avoids depending on host-specific absolute paths.
 
-Both of these builds should compile after meaningful changes:
+All four builds should compile after meaningful changes:
 
-- default build
-- `USE_ACCELERATOR` build
+- default build (both targets)
+- `USE_ACCELERATOR` build (both targets)
 
 Runtime execution cannot normally be done in a generic local environment. `xmin` runs on the Minimal 64x4 hardware. Compile validation is necessary but not sufficient.
 
@@ -355,7 +374,11 @@ The Minimal 64x4 ISA has many compound instructions that replace common multi-in
 - `LDB addr CPI imm` → `CIB imm,addr` (same A caveat)
 - `LDB a CPB b` → `CBB b,a` (note operand reversal: `CBB addr1,addr2` computes `A = *addr2 - *addr1`)
 
-**CRITICAL: The A register caveat.** `CIT`, `CIB`, `CBB`, and all `Mxx` compound moves set A to a value different from the original `LDx` sequence. If subsequent code uses A (e.g., a `CPI` chain, `STx`, `PHS`, `ADI`, or any ALU operation), the replacement is **unsafe**. Always verify A is dead or overwritten before the next use. Common traps:
+**CRITICAL: The A register caveat.** `CIT`, `CIB`, `CBB`, and all `Mxx` compound moves set A to a value different from the original `LDx` sequence. If subsequent code uses A (e.g., a `CPI` chain, `STx`, `PHS`, `ADI`, or any ALU operation), the replacement is **unsafe**. Always verify A is dead or overwritten before the next use.
+
+**Redux difference:** on the Minimal 64x4 Redux, `CIZ`/`CIT`/`CIB`/`CZZ`/`CBB` behave like the literal `LDx` + `CPx` sequence — A holds the *loaded value*, not the difference. The traps below do not exist on the Redux. However, because the two source files are kept in sync, treat A as dead after these compares in new code so it is correct on both machines.
+
+Common traps (original Minimal 64x4):
 - `LDB x CPI 3 FEQ label` followed by `CPI 1` — the second `CPI` needs A = *x, not A = *x - 3
 - `LDB x CPI '-' FNE label` followed by `STR y` — the `STR` needs A = *x to store the loaded value
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -316,7 +316,7 @@ This design keeps normal execution fast while still providing source-level diagn
 Notable diagnostics now include:
 - `Duplicate constant name` for same-scope constant redefinition.
 - `Duplicate variable name` for same-scope variable redeclaration.
-- `Value overflow` when a value assigned to `char` does not fit `0..255` (constants and typed assignments).
+- `Value overflow` when a value assigned to `char` does not fit `-128..255` (typed assignments; named `char` constants remain `0..255`).
 - `Call stack overflow` when recursion/call depth exceeds the guarded runtime limit.
 - `Buffer overflow` when `append()` is called on a full buffer (`cnt >= max`), or when a sized initializer exceeds the declared capacity.
 - `Buffer empty` when `pop()` is called on a buffer with `cnt == 0`.
@@ -426,7 +426,7 @@ The `extended-min.min64x4` implementation differs from the baseline EBNF in a fe
 - `key()` is not a core keyword in this interpreter file; keyboard/library behavior is expected via imported Min libraries and/or `call` integration.
 - Hex constants require lowercase `0x` prefix and accept uppercase or lowercase hex digits.
 - Inline hex literals wider than 16 bits (e.g. `0x12345678`) tokenize as `long` constants. Hex values `0x8000`..`0xffff` stay `int` bit patterns (so addresses and masks keep int type), unlike decimal literals >= 32768, which promote to `long`.
-- `char` values are unsigned `0..255` on assignment but sign-extend on read ("C-style" signed char): a stored byte >= `0x80` evaluates and compares as its negative value (e.g. `0xe0` reads as `-32`, never equal to `224`). The `int()` cast preserves this sign extension.
+- `char` assignment accepts `-128..255` (the low byte is stored). Equality (`==`, `!=`) with a `char` on either side compares the low 8 bits of both operands, so a stored `0xe0` equals `224`, `0xe0`, and `-32` alike. Ordering (`<`, `<=`, `>`, `>=`), arithmetic, and the `int()` cast treat chars as signed `-128..127` ("C-style", matching slu4 Min) — so `c < 0` tests the high bit, and `int(c)` of byte `0xe0` yields `-32`. Comparisons against `long` values use the full signed value (no byte-wise equality). Named `char` constants (`:=`) remain `0..255` (their grammar has no sign).
 - Constants behavior is tokenizer-time substitution, so declarations do not exist as runtime statements.
 - Long arithmetic now covers add/sub/mul/div/bitwise/shift/compare operations, plus `+=` and `-=` fast paths.
 - Constants are declaration-order dependent (no forward references) because tokenization is single-pass.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Extended Min Interpreter Architecture
 
 ## Scope
-`extended-min.min64x4` is a complete Min language runtime in one assembly file:
+`extended-min.min64x4` is a complete Min language runtime in one assembly file. A parallel port, `extended-min.min64x4r`, targets the Minimal 64x4 Redux; the two files are kept in sync line-for-line and differ only in the Redux instruction-set renames (`STZ/STT/STB/STR/STS` → `SDZ/SDT/SDB/SDR/SDS`), a few fast-vs-long branch forms, and the ISA `#require` pragmas (see `AGENTS.md` for the dual-target sync rules). Everything in this document — memory map, zero-page layout, runtime structure — applies identically to both targets. The runtime is:
 - command-line and RAM entry handling
 - source loading (`use` import support)
 - tokenization
@@ -396,7 +396,7 @@ simple-stmt = type, identifier, ['[', expr, ']'], ['@', expr ], ['=', init-expr 
             | 'append', '(', identifier, ',', comp-expr, ')'              (* append element to sized buffer *)
             | 'empty', '(', identifier, ')'                               (* clear element count of buffer *)
 
-constant    = '0x', { hexdigit }                                          (* int HEX number; bare 0x means zero *)
+constant    = '0x', { hexdigit }                                          (* HEX number: int, or long when > 0xffff; bare 0x means zero *)
             | digit, { digit }                                            (* int DEC number *)
 blob-lit    = '$(', { NEWLINE | ',' | constant }, ')'                      (* char byte blob; constants must be 0..255 *)
 factor      = constant
@@ -425,6 +425,8 @@ The `extended-min.min64x4` implementation differs from the baseline EBNF in a fe
 - `use "file"` is processed by the loader pre-pass and skipped by the tokenizer; it is not executed as a runtime statement token.
 - `key()` is not a core keyword in this interpreter file; keyboard/library behavior is expected via imported Min libraries and/or `call` integration.
 - Hex constants require lowercase `0x` prefix and accept uppercase or lowercase hex digits.
+- Inline hex literals wider than 16 bits (e.g. `0x12345678`) tokenize as `long` constants. Hex values `0x8000`..`0xffff` stay `int` bit patterns (so addresses and masks keep int type), unlike decimal literals >= 32768, which promote to `long`.
+- `char` values are unsigned `0..255` on assignment but sign-extend on read ("C-style" signed char): a stored byte >= `0x80` evaluates and compares as its negative value (e.g. `0xe0` reads as `-32`, never equal to `224`). The `int()` cast preserves this sign extension.
 - Constants behavior is tokenizer-time substitution, so declarations do not exist as runtime statements.
 - Long arithmetic now covers add/sub/mul/div/bitwise/shift/compare operations, plus `+=` and `-=` fast paths.
 - Constants are declaration-order dependent (no forward references) because tokenization is single-pass.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Extended Min
 Adds functionality to the original Min programming language for the [Minimal 64x4 Home Computer by Carsten Herting](https://github.com/slu4coder/Minimal-64x4-Home-Computer/tree/main). Based on Carsten's original work.
 
+Two target machines are supported from parallel sources:
+
+- `extended-min.min64x4` — the original Minimal 64x4
+- `extended-min.min64x4r` — the Minimal 64x4 Redux
+
+The two files are kept in sync; the only intended differences are the Redux
+instruction-set renames (the A-store family `STZ/STT/STB/STR/STS` is named
+`SDZ/SDT/SDB/SDR/SDS` on the Redux), a handful of branch-form differences
+required by the Redux fast-branch page rule, and the ISA `#require` pragmas.
+Functional changes must be applied to both files.
+
 The primary enhancements to Min in this extended version include:
 - Support for various hardware expansion cards made for the Minimal 64x4, notably the [multiplication accelerator](https://github.com/michaelkamprath/minimal-64x4-expansion-cards/tree/main/multiplier)
 - Additions of typed compile-time constants to avoid the use of magic numbers and repeated string literals.
@@ -18,6 +29,12 @@ Extended Min must be built with [the BespokeASM assembler](https://github.com/mi
 
 ```bash
 bespokeasm compile -c /path/to/slu4-minimal-64x4.yaml -n -p -t intel_hex extended-min.min64x4
+```
+
+For the Minimal 64x4 Redux, build the Redux source against the Redux instruction-set configuration instead:
+
+```bash
+bespokeasm compile -c /path/to/slu4-minimal-64x4-redux.yaml -n -p -t intel_hex extended-min.min64x4r
 ```
 
 The resulting Intel Hex output is then transferred to the Minimal 64x4 via the UART connection using its `receive` command. Once downloaded to the Minimal 64x4, pay attention to the start and stop address of the downloaded Intel Hex, then save the code to a program file on the Minimal 64x4 with the command `save XXXX YYYYY xmin`, where `XXXX` is the start address (typically hex 1000) and `YYYY` is the stop address (something around hex 3B00). 
@@ -39,7 +56,7 @@ Current skills:
 - `bespokeasm` installed and available on `PATH`
 - either `curl` or `wget` available on `PATH`
 
-The compile skill fetches the Minimal 64x4 BespokeASM configuration from the BespokeASM GitHub repository into `/tmp`, so the skills do not depend on host-specific absolute paths.
+The compile skill fetches the Minimal 64x4 (or Minimal 64x4 Redux, for `*.min64x4r` sources) BespokeASM configuration from the BespokeASM GitHub repository into `/tmp`, so the skills do not depend on host-specific absolute paths.
 
 ### Using the compile skill
 
@@ -52,6 +69,8 @@ Direct script usage:
 ```bash
 skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4
 skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4 -- -D USE_ACCELERATOR
+skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4r
+skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4r -- -D USE_ACCELERATOR
 ```
 
 ### Using the `optimize-size` skill

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Multiple simple statements may be written on one line with `;`.
 
 Extended Min supports three runtime scalar types:
 
-- `char` : 8-bit unsigned value
-- `int` : 16-bit signed value
-- `long` : 32-bit signed value
+- `char` : 8-bit byte value (see [char semantics](#char-values-assignment-and-reads) below)
+- `int` : 16-bit signed value (`-32768` to `32767`)
+- `long` : 32-bit signed value (`-2147483648` to `2147483647`)
 
 Examples:
 
@@ -141,6 +141,66 @@ Examples:
 char c = 65
 int n = 1234
 long big = 70000
+```
+
+### Char values: assignment and reads
+
+A `char` stores one byte. Assignment accepts any value from `-128` to `255` and
+stores the low byte; values outside that range raise "Value overflow".
+Equality (`==`, `!=`) with a `char` on either side compares the low 8 bits of
+both operands, so a stored byte matches whichever notation you prefer —
+unsigned decimal, hex, or signed:
+
+```xmin
+char c = 224          # stores byte 0xE0; char c = 0xe0 or char c = -32 store the same byte
+if c == 224:          # true
+if c == 0xe0:         # true
+if c == -32:          # true
+if c != 225:          # true
+```
+
+Ordering (`<`, `<=`, `>`, `>=`), arithmetic, and the `int()` cast treat chars
+as signed `-128..127` ("C-style", matching original Min), so `c < 0` is true
+for any byte `>= 0x80`, and `int(c)` for the byte `0xE0` yields `-32`. Named
+`char` constants (`:=`) accept `0..255` only.
+
+**Chars in arithmetic.** When a `char` appears in an arithmetic expression it
+is read as its *signed* value, and the result of any `+`/`-`/`*`/`/` is an
+`int`. So arithmetic on high-bit bytes goes negative, and printing the result
+shows a decimal number, not a character:
+
+```xmin
+char v = 224          # stores byte 0xE0, reads as -32 in arithmetic
+print(v)              # prints the CHARACTER for byte 0xE0 (chars print as text)
+print(v - 5)          # prints -37  (int result: -32 - 5)
+print(int(v))         # prints -32
+```
+
+For unsigned byte math, mask the `int` result back to its low byte:
+
+```xmin
+print((v - 5) and 0xff)      # prints 219  (224 - 5, as an unsigned byte)
+if char(v - 5) == 219:       # true: char() truncates to byte 0xDB,
+  print("byte match\n")      # which byte-wise-equals 219
+```
+
+Rule of thumb: the byte-wise behavior applies **only to `==` and `!=`**;
+everything else sees a signed value.
+
+### Numeric literal widths
+
+- Decimal literals that do not fit a signed 16-bit `int` (`32768` and up)
+  automatically become `long` constants.
+- Hex literals up to 16 bits (`0x0` through `0xffff`) are `int` bit patterns —
+  so addresses (`@ 0xFE00`) and masks keep `int` type; note `0x8000..0xffff`
+  read back as negative ints.
+- Hex literals wider than 16 bits (e.g. `0x12345678`) become `long` constants.
+
+```xmin
+int mask = 0xff         # 255
+int mmio = 0xfe00       # int bit pattern (reads as -512)
+long big = 40000        # decimal >= 32768 promotes to long
+long word = 0x12345678  # hex wider than 16 bits is long
 ```
 
 ## Casts
@@ -518,6 +578,11 @@ Behavior:
 - `char` payloads print as strings/byte sequences
 - `int` values print in decimal
 - `long` values print in decimal
+
+Note that arithmetic always produces an `int` (or `long`) result, so
+`print(c)` prints a character while `print(c + 0)` or `print(c - 5)` prints a
+signed decimal number — see
+[chars in arithmetic](#char-values-assignment-and-reads).
 
 ## External calls and imports
 

--- a/extended-min.min64x4
+++ b/extended-min.min64x4
@@ -418,7 +418,7 @@ t_alnumok:
 t_alloop:
     MZB z_itptr+0,strcmp_a+0 MZB z_itptr+1,strcmp_a+1             ; vgl. string @ z_itptr mit string @ z_itnext
     MZB z_itnext+0,strcmp_b+0 MZB z_itnext+1,strcmp_b+1
-    JPS strcmp CPI 0 BEQ t_alentry                                ; found? z_itptr then points to that entry
+    JPS strcmp CPI 0 FEQ t_alentry                                ; found? z_itptr then points to that entry
     AIV 16,z_itptr                                                ; no match => advance to next entry
     CIZ BYTE1(newitems),z_itptr+1 FNE t_alchk                     ; keyword->RAM boundary?
     CIZ BYTE0(newitems),z_itptr+0 FNE t_alchk
@@ -505,7 +505,7 @@ TakeOrd:
     INV z_pc LDT z_pc                               ; look at next character
     CPI 0 BEQ .takeordexit CPI 10 BEQ .takeordexit  ; exit without consuming 0 or \n
 .takeo0:
-    CPI 'r' BNE .takeo1 LDI 13 JPA .takeordret
+    CPI 'r' FNE .takeo1 LDI 13 FPA .takeordret
 .takeo1:
     CPI 'n' FNE .takeo2 LDI 10 FPA .takeordret
 .takeo2:
@@ -905,7 +905,7 @@ LongDivEC:
     LLQ z_E
     RLQ z_F
     JPS LongUCompareFC
-    CIB 1,z_flag BEQ .longdiv_skip
+    CIB 1,z_flag FEQ .longdiv_skip
     SQQ z_C,z_F
     INZ z_E+0
 .longdiv_skip:
@@ -1006,10 +1006,10 @@ scalartrue_long:
 
 int_div:
     CLZ z_flag                              ; clear the sign byte
-    CIZ 0,z_A+1 BPL .divanotneg             ; make A and B positive, evaluate the sign of result
+    CIZ 0,z_A+1 FPL .divanotneg             ; make A and B positive, evaluate the sign of result
     INZ z_flag NEV z_A                      ; store a sign, negate A                                    ;
 .divanotneg:
-    CIZ 0,z_B+1 BPL .divbnotneg
+    CIZ 0,z_B+1 FPL .divbnotneg
     INZ z_flag NEV z_B                      ; store a(nother) sign, negate B
 .divbnotneg:
     MZZ z_B+0,z_B+1 CLZ z_B+0               ; move the lower half of B to upper half, clear lower half
@@ -1357,7 +1357,7 @@ fac_passed:
     MVV slice_count,z_A
     MVV slice_count,z_cnt                                   ; z_A = anz, z_cnt = anz
     MVV slice_start,z_B
-    CIZ 1,z_type BEQ fac_elembyte
+    CIZ 1,z_type FEQ fac_elembyte
     JPS ScaleBByType
     JPS ScaleAByType                                        ; scale start/count by element width
 fac_elembyte:
@@ -1592,7 +1592,7 @@ BaseExpr:
 base_minus:
     INV z_pc                            ; consume -
     JPS Term
-    CIZ 4,z_type BNE base_minus_int
+    CIZ 4,z_type FNE base_minus_int
     JPS getL
     JPS LongNegC
     JPS StoreLongResult
@@ -1666,7 +1666,7 @@ rele_while:
     JPS getB NEV z_B
     PLS AD.Z z_B+1 PLS ADV z_B
     BMI int_true
-    JPA int_false
+    FPA int_false
 rele_lt_rhslong:
     JPS PopIntLhsHiLoToLongE
     JPS getL
@@ -1682,23 +1682,25 @@ rele_lt_lhslong:
     JPA LongCmpLtResult
 int_false:
     CLV z_A JPA rele_reuse
-int_true_pop:
-    PLS JPA int_true
-int_false_pop:
-    PLS JPA int_false
 rele_eq:
     CPI 0xd3 FNE rele_neq
     INV z_pc
     CIZ 4,z_type FEQ rele_eq_lhslong
+    LDZ z_type PHS                                          ; save lhs type: char equality is byte-wise
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_eq_rhslong
     JPS getB
-    PLS CPZ z_B+1 FNE int_false_pop
-    PLS CPZ z_B+0 BNE int_false
+    PLS STZ z_A+1 PLS STZ z_A+0 PLS                         ; restore lhs, pop lhs type into A
+    CPI 1 FEQ rele_eq_char                                  ; char on either side -> compare low bytes only
+    CIZ 1,z_type FEQ rele_eq_char
+    LDZ z_A+1 CPZ z_B+1 BNE int_false
+rele_eq_char:
+    LDZ z_A+0 CPZ z_B+0 BNE int_false
     JPA int_true
 rele_eq_rhslong:
     JPS PopIntLhsHiLoToLongE
+    PLS                                                     ; discard saved lhs type
     JPS getL
     JPS LongCompareEC
     JPA LongCmpEqResult
@@ -1714,15 +1716,21 @@ rele_neq:
     CPI 0xd4 FNE rele_leq
     INV z_pc
     CIZ 4,z_type FEQ rele_neq_lhslong
+    LDZ z_type PHS                                          ; save lhs type: char equality is byte-wise
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_neq_rhslong
     JPS getB
-    PLS CPZ z_B+1 FNE int_true_pop
-    PLS CPZ z_B+0 BNE int_true
+    PLS STZ z_A+1 PLS STZ z_A+0 PLS                         ; restore lhs, pop lhs type into A
+    CPI 1 FEQ rele_neq_char                                 ; char on either side -> compare low bytes only
+    CIZ 1,z_type FEQ rele_neq_char
+    LDZ z_A+1 CPZ z_B+1 BNE int_true
+rele_neq_char:
+    LDZ z_A+0 CPZ z_B+0 BNE int_true
     JPA int_false
 rele_neq_rhslong:
     JPS PopIntLhsHiLoToLongE
+    PLS                                                     ; discard saved lhs type
     JPS getL
     JPS LongCompareEC
     JPA LongCmpNeResult
@@ -1735,9 +1743,9 @@ rele_neq_lhslong:
     JPS LongCompareEC
     JPA LongCmpNeResult
 rele_leq:
-    CPI 0xd5 FNE rele_geq
+    CPI 0xd5 BNE rele_geq
     INV z_pc
-    CIZ 4,z_type FEQ rele_leq_lhslong
+    CIZ 4,z_type BEQ rele_leq_lhslong
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_leq_rhslong
@@ -1759,9 +1767,9 @@ rele_leq_lhslong:
     JPS LongCompareEC
     JPA LongCmpLeResult
 rele_geq:
-    CPI 0xd6 BNE rele_greater
+    CPI 0xd6 FNE rele_greater
     INV z_pc
-    CIZ 4,z_type BEQ rele_geq_lhslong
+    CIZ 4,z_type FEQ rele_geq_lhslong
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_geq_rhslong
@@ -1823,7 +1831,7 @@ rele_rts:
 ; handle logical operators: not, and, or, xor, <<, >> (and simultaeously bitwise operators)
 Expr:
     CIT 0xd9,z_pc FEQ expr_not
-    JPS RelExpr FPA expr_while
+    JPS RelExpr JPA expr_while
 expr_not:
     INV z_pc                               ; consume 'not'
     JPS RelExpr
@@ -1831,7 +1839,7 @@ expr_not:
     JPS getL
     JPS LongNotC
     JPS StoreLongResult
-    FPA expr_while
+    JPA expr_while
 expr_not_int:
     JPS get NOV z_A
 expr_reuse:
@@ -1840,9 +1848,9 @@ expr_reuse:
     MIV 1,z_cnt
 expr_while:
     LDT z_pc CPI 0xda BCC expr_rts
-    BNE expr_or
+    FNE expr_or
     INV z_pc
-    CIZ 4,z_type BEQ expr_longand_lhs
+    CIZ 4,z_type FEQ expr_longand_lhs
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS RelExpr
     CIZ 4,z_type FEQ expr_longand_rhs
@@ -1852,14 +1860,14 @@ expr_while:
 expr_longand_rhs:
     JPS PopIntLhsHiLoToLongE
     JPS LongAndStore
-    JPA expr_while
+    FPA expr_while
 expr_longand_lhs:
     JPS getL
     JPS PushLongLhsSpill
     JPS RelExpr
     JPS PopLongLhsSpill
     JPS LongAndStore
-    JPA expr_while
+    FPA expr_while
 expr_or:
     CPI 0xdb FNE expr_xor
     INV z_pc
@@ -1873,14 +1881,14 @@ expr_or:
 expr_longor_rhs:
     JPS PopIntLhsHiLoToLongE
     JPS LongOrStore
-    JPA expr_while
+    FPA expr_while
 expr_longor_lhs:
     JPS getL
     JPS PushLongLhsSpill
     JPS RelExpr
     JPS PopLongLhsSpill
     JPS LongOrStore
-    JPA expr_while
+    FPA expr_while
 expr_xor:
     CPI 0xdc FNE expr_shiftl
     INV z_pc
@@ -1895,18 +1903,18 @@ expr_xor:
 expr_longxor_rhs:
     JPS PopIntLhsHiLoToLongE
     JPS LongXorStore
-    JPA expr_while
+    FPA expr_while
 expr_longxor_lhs:
     JPS getL
     JPS PushLongLhsSpill
     JPS RelExpr
     JPS PopLongLhsSpill
     JPS LongXorStore
-    JPA expr_while
+    FPA expr_while
 expr_shiftl:
     CPI 0xdd BNE expr_shiftr
     INV z_pc
-    CIZ 4,z_type FEQ expr_longlsl_lhs
+    CIZ 4,z_type BEQ expr_longlsl_lhs
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS RelExpr
     CIZ 4,z_type FEQ expr_longlsl_rhs
@@ -2006,21 +2014,31 @@ TypedCompExpr:
     MZZ z_type,z_flag                                       ; remember source type before any widening/narrowing
     LDZ tcomp_type CPZ z_type BEQ .tcomp_rts                 ; matching types -> do nothing, else enforce type
     LDZ z_cnt+0 ANI 0xfe ORZ z_cnt+1                        ; conversions are scalar-only
-    CPI 0 BNE .tcomperror
-    CIZ 1,tcomp_type BNE .tcomp_toint                        ; desired type char?
+    CPI 0 FNE .tcomperror
+    CIZ 1,tcomp_type FNE .tcomp_toint                        ; desired type char?
     LDZ z_cnt+0 ANI 0xfe ORZ z_cnt+1                        ; int->char conversion only for one element
-    CPI 0 BNE .tcomperror
-    CIB 4,z_flag BEQ .tcomp_charlong
+    CPI 0 FNE .tcomperror
+    CIB 4,z_flag FEQ .tcomp_charlong
     MVV z_sp,longptr
     INW longptr
     LDR longptr CPI 0 FEQ .tcomp_charintdone
-    PHSPTR error24 JPA Error
+    CPI 0xff FNE .tcomp_charovf                             ; accept -128..-1: hi byte 0xff, lo bit7 set
+    LDT z_sp LL1 FCS .tcomp_chardone                        ; chardone zeroes the byte above the char
+    FPA .tcomp_charovf
 .tcomp_charlong:
-    CIT 0,z_spi FNE .tcomp_charovf
+    CIT 0,z_spi FNE .tcomp_charlongneg
     MVV z_sp,longptr
     AIW 2,longptr
     LDR longptr CPI 0 FNE .tcomp_charovf
     INW longptr LDR longptr CPI 0 FEQ .tcomp_chardone
+    FPA .tcomp_charovf
+.tcomp_charlongneg:
+    CIT 0xff,z_spi FNE .tcomp_charovf                       ; accept -128..-1: bytes 1..3 = 0xff, lo bit7 set
+    MVV z_sp,longptr
+    AIW 2,longptr
+    LDR longptr CPI 0xff FNE .tcomp_charovf
+    INW longptr LDR longptr CPI 0xff FNE .tcomp_charovf
+    LDT z_sp LL1 FCS .tcomp_chardone
 .tcomp_charovf:
     PHSPTR error24 JPA Error
 .tcomp_charintdone:
@@ -2080,19 +2098,19 @@ IfStmt:
 if_1_else:
     JPS SkipStmt
 if_while:
-    CIT 'F',z_pc BNE if_1_end
-    LDZ z_mind CPZ z_tind BNE if_1_end
+    CIT 'F',z_pc FNE if_1_end
+    LDZ z_mind CPZ z_tind FNE if_1_end
     INV z_pc
     LDS 1 CPI 0 FEQ if_2_else
     JPS SkipStmt FPA if_while
 if_2_else:
     JPS Expr JPS ScalarTruthy STS 1
-    CPI 0 BEQ if_3_else
-    JPS Block JPA if_while
+    CPI 0 FEQ if_3_else
+    JPS Block FPA if_while
 if_3_else:
-    JPS SkipStmt JPA if_while
+    JPS SkipStmt FPA if_while
 if_1_end:
-    CIT 'E',z_pc BNE if_2_end
+    CIT 'E',z_pc FNE if_2_end
     LDZ z_mind CPZ z_tind FNE if_2_end
     INV z_pc
     LDS 1 CPI 0 FEQ if_4_else
@@ -2149,7 +2167,7 @@ emit_char:
     CIZ 0,z_serial FNE .notscr
     PLS JAS _PrintChar RTS                                     ; screen only (fast path)
 .notscr:
-    CPI 2 FNE .ser
+    CPI 2 BNE .ser
     PLS JAS _PrintChar                                         ; both: screen first (JAS preserves A)
     OUT JPS _SerialWait RTS                                    ; then serial
 .ser:
@@ -2245,7 +2263,7 @@ fun_isvar:
     LDT z_pc PHS PHS INV z_pc JPS getVar                    ; consume and push ID
     PLS STZ z_refptr+1 PLS STZ z_refptr+0                   ; return pointer to ref variable *type*
     SIV 7,z_nextvar                                         ; down to ->type
-    LDT z_refptr CPT z_nextvar FNE fun_typeerr              ; error Reference type mismatch
+    LDT z_refptr CPT z_nextvar BNE fun_typeerr              ; error Reference type mismatch
     INV z_nextvar INV z_refptr                              ; advance to ->cnt
     LDT z_refptr STT z_nextvar INV z_nextvar INV z_refptr   ; -> cnt
     LDT z_refptr STT z_nextvar INV z_nextvar INV z_refptr
@@ -2301,7 +2319,7 @@ fun_whileex:
     MVV z_sp,z_spi
     INV z_spi
     PLS STZ z_nextvar+1 PLS STZ z_nextvar+0
-    CIZ 0,z_halt FEQ fun_nohalt
+    CIZ 0,z_halt BEQ fun_nohalt
     LDI 0xfb AN.Z z_halt                                    ; clear RETURN flag
     LDZ z_cnt+0 ORZ z_cnt+1 CPI 0 FEQ fun_rts
     MZB z_sp+0,fun_dst+0                                    ; move return data
@@ -2322,9 +2340,9 @@ fun_nohalt:
     CLV z_cnt DEZ call_depth RTS                            ; no 'return' happened
 
 DefStmt:
-    CIT 'S',z_pc BNE deferror
-    CIZ 0,z_sub BNE deferror
-    CIZ 0,z_mind BNE deferror
+    CIT 'S',z_pc FNE deferror
+    CIZ 0,z_sub FNE deferror
+    CIZ 0,z_mind FNE deferror
     INV z_pc                                                ; consume TN_CALL
     LDT z_pc STT z_nextcall INV z_pc INV z_nextcall         ; consume and store call ID
     JPS AssertORound                                        ; consume (
@@ -2350,7 +2368,7 @@ ass_operator:
     LDS 6 STZ assptr+0 LDS 5 STZ assptr+1                   ; vp->type
     LDT assptr STZ tcomp_type                               ; request typed comp-expr (now z_type = vp->type)
     JPS TypedCompExpr
-    PLS CPI 0xff FEQ ass_nooffset                           ; pull and test offset MSB
+    PLS CPI 0xff BEQ ass_nooffset                           ; pull and test offset MSB
     STB ass_dst+1 STZ z_A+1                                 ; offset -> ass_dst, z_A
     PLS STB ass_dst+0 STZ z_A+0
     AVV z_cnt,z_A                                           ; RANGE SAFETY-CHECK 1: z_A = z_cnt + offset
@@ -2433,16 +2451,16 @@ ass_nooffa:
     LDT assptr STZ z_A+0 INV assptr                         ; z_A = ->ptr
     LDT assptr STZ z_A+1
 ass_offaset:
-    CIZ 1,z_tmp_type FEQ ass_aachar                         ; char path
+    CIZ 1,z_tmp_type BEQ ass_aachar                         ; char path
     CIZ 4,z_tmp_type BEQ ass_aalong                         ; long path
     LDT z_A STZ z_B+0 INV z_A                               ; int path: load 2 bytes
     LDT z_A STZ z_B+1
-    CIZ 'a',z_tmp_fastop FNE ass_fsubint
+    CIZ 'a',z_tmp_fastop BNE ass_fsubint
     LDT z_pc ADV z_B INV z_pc                               ; add fast int
     LDT z_pc AD.Z z_B+1 STT z_A INV z_pc
     DEV z_A LDZ z_B+0 STT z_A RTS
 ass_fsubint:
-    CIZ 's',z_tmp_fastop BNE ass_error
+    CIZ 's',z_tmp_fastop FNE ass_error
     LDT z_pc SUV z_B INV z_pc                               ; sub fast int
     LDT z_pc SU.Z z_B+1 STT z_A INV z_pc
     DEV z_A LDZ z_B+0 STT z_A RTS
@@ -2451,7 +2469,7 @@ ass_aachar:
     LDT z_A ADT z_pc STT z_A                                ; add fast char
     AIV 2,z_pc RTS
 ass_fsubchar:
-    CIZ 's',z_tmp_fastop BNE ass_error
+    CIZ 's',z_tmp_fastop FNE ass_error
     LDT z_A SUT z_pc STT z_A                                ; sub fast char
     AIV 2,z_pc RTS
 ass_aalong:
@@ -2518,7 +2536,7 @@ var_typok:
     LDZ z_A+0 STT z_nextvar INV z_nextvar                      ; vp->ptr
     LDZ z_A+1 STT z_nextvar INV z_nextvar                      ; z_nextvar at ->max
     ; write ->max: use z_bufsize if [N] specified, else 0xffff
-    LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 BNE .abs_sizedmax
+    LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 FNE .abs_sizedmax
     MIT 0xff,z_nextvar INV z_nextvar                           ; vp->max = 0xffff (no [N])
     MIT 0xff,z_nextvar INV z_nextvar
     FPA .abs_maxdone
@@ -2582,11 +2600,11 @@ var_localvar:
     LDZ z_sp+0 STT z_nextvar INV z_nextvar                   ; write z_sp ->ptr
     LDZ z_sp+1 STT z_nextvar INV z_nextvar                   ; z_nextvar at ->max
     LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 FNE var_localsized
-    CIT '=',z_pc BEQ var_localinit
-    JPA var_locelse
+    CIT '=',z_pc FEQ var_localinit
+    FPA var_locelse
 
 var_localsized:
-    CIT '=',z_pc BEQ var_sizedinit
+    CIT '=',z_pc FEQ var_sizedinit
     ; uninitialized sized buffer: cnt = N, max = N
     SIV 4,z_nextvar                                          ; back to ->cnt
     LDZ z_bufsize+0 STT z_nextvar INV z_nextvar              ; ->cnt = N
@@ -2667,7 +2685,7 @@ var_locelse:
 ; Call after TypedCompExpr when additional comma-separated values may follow.
 ; Accumulates element count into z_cnt; data is laid out consecutively on the stack.
 VarCommaConcat:
-    CIT ',',z_pc BNE .done
+    CIT ',',z_pc FNE .done
     INV z_pc                                                 ; consume comma
     LDZ z_sp+0 PHS LDZ z_sp+1 PHS                            ; save sp
     LDZ z_cnt+0 PHS LDZ z_cnt+1 PHS                          ; save cnt
@@ -2679,7 +2697,7 @@ VarCommaConcat:
     PLS AD.Z z_cnt+1 PLS ADV z_cnt                           ; accumulate total count
     PLS STZ z_sp+1 PLS STZ z_sp+0                            ; restore original sp
     MVV z_sp,z_spi INV z_spi
-    JPA VarCommaConcat
+    FPA VarCommaConcat
 .done:
     RTS
 
@@ -2704,8 +2722,8 @@ AppendStmt:
     LDT facptr STZ z_cnt+1
     ; bounds check: cnt < max (z_A < z_cnt)
     LDZ z_A+1 CPZ z_cnt+1 FCC append_ok
-    BNE var_buferr                              ; cnt_MSB > max_MSB → overflow
-    LDZ z_A+0 CPZ z_cnt+0 BCS var_buferr        ; cnt >= max → overflow
+    FNE var_buferr                              ; cnt_MSB > max_MSB → overflow
+    LDZ z_A+0 CPZ z_cnt+0 FCS var_buferr        ; cnt >= max → overflow
 append_ok:
     SIV 5,facptr                                ; facptr back to ->cnt_lsb
     LDZ facptr+0 PHS LDZ facptr+1 PHS           ; save cnt_ptr on CPU stack
@@ -2755,7 +2773,7 @@ fac_pop:
     LDT facptr STZ z_A+0 INV facptr             ; z_A = cnt
     LDT facptr STZ z_A+1
     ; check cnt > 0
-    LDZ z_A+0 ORZ z_A+1 CPI 0 BEQ fac_pop_empty
+    LDZ z_A+0 ORZ z_A+1 CPI 0 FEQ fac_pop_empty
     DEV z_A                                     ; z_A = cnt - 1
     SIV 1,facptr                                ; facptr back to ->cnt_lsb
     LDZ z_A+0 STT facptr INV facptr             ; write new cnt
@@ -2827,13 +2845,13 @@ vardup_end: .2byte 0xffff                  ; TODO: Consider moving to zero page
 
 Statement:
     LDZ z_mind CPZ z_tind FEQ stmtnormal
-    FMI stmtblockend
+    BMI stmtblockend
     LDI BYTE0(error11) PHS LDI BYTE1(error11) PHS JPA Error ; error unexpected indent
 stmtnormal:
     LDT z_pc CPI 'I' FNE stmtnext1
     INV z_pc JPS IfStmt RTS
 stmtnext1:
-    CPI 'W' FNE stmtnext2
+    CPI 'W' BNE stmtnext2
     INV z_pc JPS WhileStmt RTS
 stmtnext2:
     CPI 'D' FNE stmtsimple
@@ -2867,7 +2885,7 @@ ConstLinePrelude:
 
 ; maintains function-local constant scope by indentation
 ConstScopeState:
-    CIB 0,const_local_active BEQ .wait
+    CIB 0,const_local_active FEQ .wait
     CBB const_fun_indent,ind FCC .wait
     MBB const_local_base+0,const_next+0
     MBB const_local_base+1,const_next+1
@@ -2931,10 +2949,10 @@ ConstClassifyTypeName:
     CPI 0 FEQ .hit
     INW const_src
     INW const_tmp
-    FPA .cmploop
+    JPA .cmploop
 .next:
     AIW 15,const_scan
-    FPA .loop
+    JPA .loop
 .hit:
     MZB z_itnext+0,const_src+0
     MZB z_itnext+1,const_src+1
@@ -2957,11 +2975,11 @@ TryConstDecl:
     MZB z_pc+1,const_savepc+1
     JPS TakeAlNum
     JAS ConstClassifyTypeName
-    CPI 0 FEQ .failrestore
+    CPI 0 BEQ .failrestore
     STB const_decl_type
 .typeok:
     JPS Next
-    JPS TakeAlNum CPI 0 FEQ .bad
+    JPS TakeAlNum CPI 0 BEQ .bad
     CPI 14 FCC .nameok
     LDI BYTE0(error01) PHS LDI BYTE1(error01) PHS JPA SourceError
 .nameok:
@@ -2974,7 +2992,7 @@ TryConstDecl:
 .sepws1take:
     INV z_pc FPA .sepws1
 .sepc1:
-    CPI ':' FNE .failrestore
+    CPI ':' BNE .failrestore
     INV z_pc
 .sepws2:
     LDT z_pc CPI ' ' FEQ .sepws2take
@@ -2984,26 +3002,26 @@ TryConstDecl:
 .sepws2take:
     INV z_pc FPA .sepws2
 .sepc2:
-    CPI '=' FNE .bad
+    CPI '=' BNE .bad
     INV z_pc
     LDB const_decl_type CPI 1 FNE .int_rhs
 .char_rhs:
     JPS ConstParseNumericRhs CPI 1 FEQ .char_num
-    JPS ConstParseStringRhs CPI 1 FNE .bad
+    JPS ConstParseStringRhs CPI 1 BNE .bad
     FPA .tail
 .char_num:
     CLB const_rhs_type
-    CIB 4,const_num_type FEQ .overflow
+    CIB 4,const_num_type BEQ .overflow
     CIB 0,const_data+1 FEQ .tail
-    FPA .overflow
+    JPA .overflow
 .int_rhs:
-    JPS ConstParseNumericRhs CPI 1 FNE .bad
+    JPS ConstParseNumericRhs CPI 1 BNE .bad
     CLB const_rhs_type
     CIB 4,const_decl_type FNE .int_check
     MIB 4,const_num_type
     FPA .tail
 .int_check:
-    CIB 4,const_num_type FEQ .overflow
+    CIB 4,const_num_type BEQ .overflow
     FPA .tail
 .tail:
     JPS Next
@@ -3034,10 +3052,10 @@ ConstParseNumericRhs:
     LDZ z_pc+0 PHS LDZ z_pc+1 PHS
     JPS Next
     CPI '0' FCC .name
-    CPI '9' BLE .lit
+    CPI '9' FLE .lit
 .name:
-    JPS TakeAlNum CPI 0 BEQ .failrestore
-    CPI 14 BCS .failrestore
+    JPS TakeAlNum CPI 0 FEQ .failrestore
+    CPI 14 FCS .failrestore
     JAS ConstClassifyTypeName
     CPI 1 FNE .lookupint
     JPS Next
@@ -3096,14 +3114,14 @@ ConstParseNumericRhs:
 ConstParseStringRhs:
     LDZ z_pc+0 PHS LDZ z_pc+1 PHS
     JPS Next
-    CPI '"' FEQ .literal
-    JPS TakeAlNum CPI 0 BEQ .failrestore
-    CPI 14 BCS .failrestore
+    CPI '"' BEQ .literal
+    JPS TakeAlNum CPI 0 FEQ .failrestore
+    CPI 14 FCS .failrestore
     MZB z_itnext+0,const_src+0
     MZB z_itnext+1,const_src+1
     MIW conststrtab,const_start
-    JPS ConstLookupString CPI 1 BEQ .alias
-    JPA .failrestore
+    JPS ConstLookupString CPI 1 FEQ .alias
+    FPA .failrestore
 .literal:
     MZB z_pc+0,const_text_ptr+0
     MZB z_pc+1,const_text_ptr+1
@@ -3115,7 +3133,7 @@ ConstParseStringRhs:
     CPI 10 FEQ .litbail
     JPS TakeOrd
     INW const_text_len
-    JPA .litloop
+    FPA .litloop
 .litclose:
     INV z_pc
 .litbail:
@@ -3163,8 +3181,8 @@ ConstParseNumber:
 ; overflow:  A=2, z_pc advanced through consumed digits, z_C undefined
 ParseDecimalLiteral32:
     LDT z_pc CPI '0'
-    CPI '0' FCC .not_dec
-    CPI '9' FGT .not_dec
+    CPI '0' BCC .not_dec
+    CPI '9' BGT .not_dec
     CLQ z_C
 .loop:
     MQQ z_C,z_E
@@ -3172,15 +3190,15 @@ ParseDecimalLiteral32:
     LLQ z_C
     LLQ z_C
     LLQ z_C
-    AQQ z_E,z_C FCS .overflow
+    AQQ z_E,z_C BCS .overflow
     LDT z_pc SUI '0' PHS
     PLS AD.Z z_C+0
     LDI 0 AC.Z z_C+1
     LDI 0 AC.Z z_C+2
-    LDI 0 AC.Z z_C+3 FCS .overflow
+    LDI 0 AC.Z z_C+3 BCS .overflow
     INV z_pc
     LDT z_pc CPI '0' FCC .done
-    CPI '9' FLE .loop
+    CPI '9' BLE .loop
 .done:
     LDI 1 RTS
 .overflow:
@@ -3197,10 +3215,10 @@ ParseDecimalLiteral32:
 ;   - prefix must be lowercase 0x
 ;   - digits may be 0-9, a-f, or A-F
 ParseHexLiteral:
-    CIT '0',z_pc BNE .not_hex
+    CIT '0',z_pc FNE .not_hex
     INV z_pc
     LDT z_pc CPI 'x' FEQ .prefix_ok
-    CPI 'X' BEQ .bad_prefix
+    CPI 'X' FEQ .bad_prefix
     DEV z_pc
     LDI 0 RTS
 .prefix_ok:
@@ -3208,17 +3226,17 @@ ParseHexLiteral:
     CLQ z_C
 .loop:
     LDT z_pc
-    CPI '9' BGT .maybe_upper
-    CPI '0' BCS .digit
-    JPA .done
+    CPI '9' FGT .maybe_upper
+    CPI '0' FCS .digit
+    FPA .done
 .maybe_upper:
     CPI 'F' FGT .maybe_lower
-    CPI 'A' BCS .upper
-    JPA .done
+    CPI 'A' FCS .upper
+    FPA .done
 .maybe_lower:
-    CPI 'f' BGT .done
-    CPI 'a' BCS .lower
-    JPA .done
+    CPI 'f' FGT .done
+    CPI 'a' FCS .lower
+    FPA .done
 .digit:
     SUI '0'
     FPA .accum
@@ -3237,7 +3255,7 @@ ParseHexLiteral:
     LDI 0 AC.Z z_C+1
     LDI 0 AC.Z z_C+2
     LDI 0 AC.Z z_C+3 FCS .overflow
-    INV z_pc JPA .loop
+    INV z_pc FPA .loop
 .done:
     LDI 1 RTS
 .overflow_pop:
@@ -3282,7 +3300,7 @@ ConstNameExists:
 
 ; add constant name at const_name with value in const_data into table
 ConstAddEntry:
-    JPS ConstNameExists CPI 1 FEQ .redef
+    JPS ConstNameExists CPI 1 BEQ .redef
 .nodup:
     MBB const_next+0,const_tmp+0
     MBB const_next+1,const_tmp+1
@@ -3301,7 +3319,7 @@ ConstAddEntry:
     MIZ 14,z_count
 .cpy:
     LDR const_src STR const_dst INW const_src INW const_dst
-    DEZ z_count BNE .cpy
+    DEZ z_count FNE .cpy
     LDB const_num_type STR const_dst INW const_dst
     LDB const_data+0 STR const_dst INW const_dst
     LDB const_data+1 STR const_dst INW const_dst
@@ -3348,16 +3366,16 @@ ConstCopyStringLiteralToDst:
 
 ; add string constant/alias named const_name with payload in const_text_*
 ConstAddStringEntry:
-    JPS ConstNameExists CPI 1 FEQ .redef
+    JPS ConstNameExists CPI 1 BEQ .redef
     MBB consts_next+0,const_tmp+0
     MBB consts_next+1,const_tmp+1
     AIW const_str_entry_size,const_tmp
     MWV const_text_len,z_A
     LDZ z_A+1 AD.B const_tmp+1
     LDZ z_A+0 ADW const_tmp
-    CIB BYTE1(conststrtab_end),const_tmp+1 BCC .store
+    CIB BYTE1(conststrtab_end),const_tmp+1 FCC .store
     FNE .full
-    CIB BYTE0(conststrtab_end),const_tmp+0 BCC .store
+    CIB BYTE0(conststrtab_end),const_tmp+0 FCC .store
 .full:
     LDI BYTE0(error07) PHS LDI BYTE1(error07) PHS JPA SourceError
 .redef:
@@ -3369,7 +3387,7 @@ ConstAddStringEntry:
     MIZ 14,z_count
 .cpyname:
     LDR const_src STR const_dst INW const_src INW const_dst
-    DEZ z_count BNE .cpyname
+    DEZ z_count FNE .cpyname
     MBB const_dst+0,const_scan+0
     MBB const_dst+1,const_scan+1
     AIW 2,const_dst
@@ -3393,14 +3411,14 @@ ConstLookupNumeric:
     CLB z_flag
 .loop:
     CBB const_next+1,const_scan+1 FCC .cmp
-    FNE .done
+    BNE .done
     CBB const_next+0,const_scan+0 FCC .cmp
-    FPA .done
+    JPA .done
 .cmp:
     MBB const_src+0,strcmp_b+0
     MBB const_src+1,strcmp_b+1
     MBB const_scan+0,strcmp_a+0 MBB const_scan+1,strcmp_a+1
-    JPS strcmp CPI 0 FNE .nextent
+    JPS strcmp CPI 0 BNE .nextent
     MBB const_scan+0,const_tmp+0
     MBB const_scan+1,const_tmp+1
     AIW 14,const_tmp
@@ -3412,7 +3430,7 @@ ConstLookupNumeric:
     MIB 1,z_flag
 .nextent:
     AIW const_entry_size,const_scan
-    FPA .loop
+    JPA .loop
 .done:
     CIZ 1,z_flag FEQ .hit
     LDI 0 RTS
@@ -3426,10 +3444,10 @@ ConstLookupString:
     MBB const_start+1,const_scan+1
     CLB z_flag
 .loop:
-    CBB consts_next+1,const_scan+1 BCC .cmp
-    BNE .done
+    CBB consts_next+1,const_scan+1 FCC .cmp
+    FNE .done
     CBB consts_next+0,const_scan+0 FCC .cmp
-    JPA .done
+    FPA .done
 .cmp:
     MBB const_src+0,strcmp_b+0
     MBB const_src+1,strcmp_b+1
@@ -3460,7 +3478,7 @@ ConstLookupString:
     LDZ z_A+0 ADW const_tmp
     MBB const_tmp+0,const_scan+0
     MBB const_tmp+1,const_scan+1
-    JPA .loop
+    FPA .loop
 .done:
     CIZ 1,z_flag FEQ .hit
     LDI 0 RTS
@@ -3472,7 +3490,7 @@ ConstSubstitute:
     MZB z_itnext+0,const_src+0
     MZB z_itnext+1,const_src+1
     MIW consttab,const_start
-    JPS ConstLookupNumeric CPI 1 FNE .fail
+    JPS ConstLookupNumeric CPI 1 BNE .fail
     CIB 4,const_num_type FEQ .emitlong
     MIT 0xd0,z_dst INV z_dst
     LDB const_data+0 STT z_dst INV z_dst
@@ -3598,25 +3616,25 @@ linenext4:
     CPI '1' FNE linenext5
     INV z_pc LDI 1 PHS JPS VarDefinition PLS JPA linecont
 linenext5:
-    CPI '2' FNE linenext6
+    CPI '2' BNE linenext6
     INV z_pc LDI 2 PHS JPS VarDefinition PLS JPA linecont
 linenext6:
     CPI '4' FNE linenext6b
     INV z_pc LDI 4 PHS JPS VarDefinition PLS JPA linecont
 linenext6b:
-    CPI 'C' FNE linenext7
+    CPI 'C' BNE linenext7
     INV z_pc JPS CallStmt JPA linecont
 linenext7:
-    CPI 'P' BNE linenext8
-    INV z_pc JPS PrintStmt JPA linecont
+    CPI 'P' FNE linenext8
+    INV z_pc JPS PrintStmt FPA linecont
 linenext8:
     CPI 'Q' FNE linenext9
-    INV z_pc JPS SerialStmt JPA linecont
+    INV z_pc JPS SerialStmt FPA linecont
 linenext9:
     CPI 'O' FNE linenext10
-    INV z_pc JPS OutputStmt JPA linecont
+    INV z_pc JPS OutputStmt FPA linecont
 linenext10:
-    CPI 'A' BNE linenext11
+    CPI 'A' FNE linenext11
     INV z_pc JPS AppendStmt FPA linecont
 linenext11:
     CPI 'G' FNE lineerror
@@ -3624,7 +3642,7 @@ linenext11:
 lineerror:
     PHSPTR error02 JPA Error                              ; error invalid simple stmt
 linecont:
-    LDT z_pc CPI 0xe0 BCS lineindent                      ; end of the line (indent) reached?
+    LDT z_pc CPI 0xe0 FCS lineindent                      ; end of the line (indent) reached?
     CIZ 0,z_halt BEQ SimpleLine                           ; any halt flag set?
     RTS
 lineindent:
@@ -3677,7 +3695,7 @@ whileloop:
     JPS Expr JPS ScalarTruthy
     CPI 0 FEQ whiledone
     JPS Block
-    CIZ 0,z_halt FNE whilehalt
+    CIZ 0,z_halt BNE whilehalt
     LDS 1 STZ z_pc+1 LDS 2 STZ z_pc+0
     FPA whileloop
 whiledone:
@@ -3701,7 +3719,7 @@ whilehaltrts:
 ; Source syntax: $(0xNN, 0xNN, ...)
 
 t_blobstart:
-    INV z_pc CIT '(',z_pc BNE t_bloberror
+    INV z_pc CIT '(',z_pc FNE t_bloberror
     INV z_pc
     MIT 0xcf,z_dst INV z_dst
     MVV z_dst,z_PtrC
@@ -3709,19 +3727,19 @@ t_blobstart:
     CLV z_cnt
 t_blobloop:
     JPS Next
-    CPI 10 BNE t_blobnotnl
-    INW g_line INV z_pc JPA t_blobloop
+    CPI 10 FNE t_blobnotnl
+    INW g_line INV z_pc FPA t_blobloop
 t_blobnotnl:
-    CPI ')' BEQ t_blobdone
+    CPI ')' FEQ t_blobdone
     CPI ',' FNE t_blobhex
-    INV z_pc JPA t_blobloop
+    INV z_pc FPA t_blobloop
 t_blobhex:
     JPS ParseHexLiteral
-    CPI 2 BEQ t_bloboverflow
-    CPI 1 BNE t_bloberror
-    LDZ z_C+1 ORZ z_C+2 ORZ z_C+3 CPI 0 BNE t_bloboverflow
+    CPI 2 FEQ t_bloboverflow
+    CPI 1 FNE t_bloberror
+    LDZ z_C+1 ORZ z_C+2 ORZ z_C+3 CPI 0 FNE t_bloboverflow
     LDZ z_C+0 STT z_dst INV z_dst INV z_cnt
-    JPA t_blobloop
+    FPA t_blobloop
 t_blobdone:
     INV z_pc
     LDZ z_cnt+0 STT z_PtrC INV z_PtrC

--- a/extended-min.min64x4r
+++ b/extended-min.min64x4r
@@ -16,6 +16,13 @@
 ; -------
 ; Compilable by Bespoke ASM + hardware multiplier              03.07.2026
 ; Added additional features, notably the long type             03.15.2026
+; ported to Minimal 64x4 Redux                                 08.07.2026
+; ------------------------------------------------------------------------
+; This file targets the Minimal 64x4 Redux. It is kept in sync with
+; extended-min.min64x4 (original Minimal 64x4); the only intended
+; difference is the instruction set: the Redux renames the A-store
+; family STZ/STT/STB/STR/STS to SDZ/SDT/SDB/SDR/SDS. Apply functional
+; changes to both files.
 ; ------------------------------------------------------------------------
 
 ; LICENSING INFORMATION
@@ -47,8 +54,8 @@
 ; ----------------`----------------------------------------------------------------------
 ; MAIN PROCEDURE (FILE LOADER, TOKENIZER, INTERPRETER)
 ; --------------------------------------------------------------------------------------
-#require __LANGUAGE_NAME__ == slu4-min64x4-asm
-#require __LANGUAGE_VERSION__ >= 1.1.0
+#require __LANGUAGE_NAME__ == slu4-min64x4-redux-asm
+#require __LANGUAGE_VERSION__ >= 1.4.0
 #require __BESPOKEASM_VERSION__ >= 0.7.2
 
 #create_memzone MIN_INTERPRETER  0x1000 0x3FFF
@@ -96,8 +103,8 @@ LoadFileTo:
     LDI 0 RTS                                        ; return a failure (file not found)
 lf_found:
     AIV 22,z_PtrA JPS OS_FlashA                      ; search for bytesize of file
-    RDR z_PtrA STZ z_PtrB+0 INV z_PtrA JPS OS_FlashA ; bytesize -> PtrB (PtrA now points to data)
-    RDR z_PtrA STZ z_PtrB+1 INV z_PtrA JPS OS_FlashA
+    RDR z_PtrA SDZ z_PtrB+0 INV z_PtrA JPS OS_FlashA ; bytesize -> PtrB (PtrA now points to data)
+    RDR z_PtrA SDZ z_PtrB+1 INV z_PtrA JPS OS_FlashA
     MVV z_PtrD,z_A
     AVV z_PtrB,z_A                                   ; z_A = trailing '\0' address after copied file
     CIZ BYTE1(source_top),z_A+1 FCC lf_loadloop
@@ -110,7 +117,7 @@ lf_ramfull:
     JPA _Prompt
 lf_loadloop:
     DEV z_PtrB FCC lf_success                        ; done with copying?
-    RDR z_PtrA STT z_PtrD                            ; load byte from FLASH, switch FLASH off
+    RDR z_PtrA SDT z_PtrD                            ; load byte from FLASH, switch FLASH off
     INV z_PtrD INV z_PtrA JPS OS_FlashA
     FPA lf_loadloop
 lf_success:
@@ -183,8 +190,8 @@ PrintEnter:
 ; advances z_PtrD and generates an entry to the sources vector
 ; -----------------------------------------------------------
 LoadFile:
-    LDZ z_PtrD+0 STT z_nextsrc INV z_nextsrc                      ; emplace first source addr into sources vector
-    LDZ z_PtrD+1 STT z_nextsrc INV z_nextsrc
+    LDZ z_PtrD+0 SDT z_nextsrc INV z_nextsrc                      ; emplace first source addr into sources vector
+    LDZ z_PtrD+1 SDT z_nextsrc INV z_nextsrc
     MZB z_nextsrc+0,snameptr+0                                    ; filename pointer in sources
     MZB z_nextsrc+1,snameptr+1
     MWV _ReadPtr,z_A                                              ; remember filename start
@@ -201,11 +208,11 @@ returnchar:
     LDI 10 JAS _PrintChar
     JPA _Prompt
 foundfile:
-    LDB _ReadPtr+0 SUZ z_A+0 STZ z_B+0                            ; calc filename byte count -> z_B+0
+    LDB _ReadPtr+0 SUZ z_A+0 SDZ z_B+0                            ; calc filename byte count -> z_B+0
 snameloop:
     DEZ z_B+0 FCC finalizesrc                                     ; some filename chars to write?
     LDT z_A
-    STB @snameptr: 0xffff                                         ; copy filename into sources vector
+    SDB @snameptr: 0xffff                                         ; copy filename into sources vector
     INV z_A INW snameptr FPA snameloop
 finalizesrc:
     MIR 0,snameptr                                                ; finalize the name in sources
@@ -213,10 +220,10 @@ finalizesrc:
     RTS
 
 Loader:
-    LDI BYTE0(firstsrc) STZ z_nextsrc+0                           ; init sources vector
-    LDI BYTE1(firstsrc) STZ z_nextsrc+1
-    LDI BYTE0(file) STZ z_PtrD+0 STZ z_pc+0                       ; init z_PtrD (points beyond last source file)
-    LDI BYTE1(file) STZ z_PtrD+1 STZ z_pc+1                       ; init z_pc (used by Loader to parse for use ...)
+    LDI BYTE0(firstsrc) SDZ z_nextsrc+0                           ; init sources vector
+    LDI BYTE1(firstsrc) SDZ z_nextsrc+1
+    LDI BYTE0(file) SDZ z_PtrD+0 SDZ z_pc+0                       ; init z_PtrD (points beyond last source file)
+    LDI BYTE1(file) SDZ z_PtrD+1 SDZ z_pc+1                       ; init z_pc (used by Loader to parse for use ...)
     LDR _ReadPtr CPI 33 BCS appendfile                            ; load first source from commandline or use text?
     MIT BYTE0(file),z_nextsrc INV z_nextsrc                       ; emplace first source addr into sources vector
     MIT BYTE1(file),z_nextsrc INV z_nextsrc
@@ -270,8 +277,8 @@ t_srcwhile:
     FNE t_srcok
     CIB BYTE0(firstsrc),srcptr+0 BCC t_endreached                 ; same page: below start offset?
 t_srcok:
-    LDR srcptr STZ z_pc+0 INW srcptr                              ; extract ->ptr to source code
-    LDR srcptr STZ z_pc+1 INW srcptr                              ; srcptr now points to filename (for error)
+    LDR srcptr SDZ z_pc+0 INW srcptr                              ; extract ->ptr to source code
+    LDR srcptr SDZ z_pc+1 INW srcptr                              ; srcptr now points to filename (for error)
     MIB 1,g_line+0 CLB g_line+1                                   ; set line number to 1
 
 t_while:
@@ -292,7 +299,7 @@ t_eatname:
     JPA t_pckeep
 
 t_pcback:
-    PLS STZ z_pc+1 PLS STZ z_pc+0 JPA t_measure                   ; go back to u...
+    PLS SDZ z_pc+1 PLS SDZ z_pc+0 JPA t_measure                   ; go back to u...
 t_pckeep:
     PLS PLS
 t_measure:
@@ -309,7 +316,7 @@ t_inddone:
 t_inderror:
     LDI BYTE0(error11) PHS LDI BYTE1(error11) PHS JPA SourceError ; error invalid indent
 t_indokay:
-    NOT DEC STB ind                                               ; code indentation range -1..30 -> 0xff..0xe0
+    NOT DEC SDB ind                                               ; code indentation range -1..30 -> 0xff..0xe0
 
     JPS Next CPI 0 BEQ t_srcwhile                                 ; break if EOF
 
@@ -319,7 +326,7 @@ t_indokay:
 ; START OF NON_EMPTY LINE
 t_notenter:
     JPS ConstLinePrelude CPI 1 BEQ t_while                        ; handles const scope/declaration/def tracking
-    LDB ind STT z_dst INV z_dst                                   ; write indentation marker
+    LDB ind SDT z_dst INV z_dst                                   ; write indentation marker
 
 ; START OF LINE PROCESSING
 
@@ -365,11 +372,11 @@ t_next8:
 
 t_next9:
     CPI '"' FNE t_next10                                          ; "STRING"
-    STT z_dst INV z_dst INV z_pc                                  ; write and consume "
+    SDT z_dst INV z_dst INV z_pc                                  ; write and consume "
 t_string:
     LDT z_pc CPI '"' FEQ t_strclose                               ; close and consume "
     CPI 0 FEQ t_strbail CPI 10 FEQ t_strbail                      ; close without consuming on 0 and 10
-    JPS TakeOrd STT z_dst INV z_dst                               ; consume and store (special) char
+    JPS TakeOrd SDT z_dst INV z_dst                               ; consume and store (special) char
     FPA t_string
 t_strclose:
     INV z_pc                                                      ; consume source char
@@ -389,15 +396,15 @@ t_next10a:
 
 t_writeconst:
     MIT 0xd0,z_dst INV z_dst                                      ; ... write word TN_CONST
-    LDZ z_C+0 STT z_dst INV z_dst
-    LDZ z_C+1 STT z_dst INV z_dst
+    LDZ z_C+0 SDT z_dst INV z_dst
+    LDZ z_C+1 SDT z_dst INV z_dst
     JPA t_stopcheck
 t_writelong:
     MIT 0xd1,z_dst INV z_dst                                      ; ... write long TN_CONST
-    LDZ z_C+0 STT z_dst INV z_dst
-    LDZ z_C+1 STT z_dst INV z_dst
-    LDZ z_C+2 STT z_dst INV z_dst
-    LDZ z_C+3 STT z_dst INV z_dst
+    LDZ z_C+0 SDT z_dst INV z_dst
+    LDZ z_C+1 SDT z_dst INV z_dst
+    LDZ z_C+2 SDT z_dst INV z_dst
+    LDZ z_C+3 SDT z_dst INV z_dst
     JPA t_stopcheck
 
 ; omit these characters (comma passes through for sized-init lists), stop check not needed
@@ -429,11 +436,11 @@ t_alchk:
     AIV 14,z_itnext                                               ; reached z_itptr == z_itnext, keep name
     JPS Next CPI '(' FNE t_variable                               ; END REACHED w/o match: make it a new item
     MIT 'S',z_itnext INV z_itnext                                 ; write call
-    LDB cid STT z_itnext INV z_itnext                             ; z_itnext points to free item now
+    LDB cid SDT z_itnext INV z_itnext                             ; z_itnext points to free item now
     INB cid FPA t_idcheck
 t_variable:
     MIT 'V',z_itnext INV z_itnext
-    LDB vid STT z_itnext INV z_itnext                             ; z_itnext points to free item now
+    LDB vid SDT z_itnext INV z_itnext                             ; z_itnext points to free item now
     INB vid
 t_idcheck:
     CPI 0xe0 FCS t_idfull                                         ; don't let these numbers be confused with indents
@@ -442,7 +449,7 @@ t_idfull:
     LDI BYTE0(error07) PHS LDI BYTE1(error07) PHS JPA SourceError ; error too many tokens
 t_alentry:
     AIV 14,z_itptr                                                ; z_itptr points to start of relevant entry
-    LDT z_itptr STT z_dst INV z_itptr INV z_dst                   ; write token
+    LDT z_itptr SDT z_dst INV z_itptr INV z_dst                   ; write token
     LDT z_itptr CPI 0xff FEQ t_stopcheck                          ; do not store invalid ID (as used for keywords)
     FPA t_puttoken                                                ; and write id != 0xff
 
@@ -450,7 +457,7 @@ t_else:
     LDT z_pc PHS INV z_pc PLS                                     ; else *dst++ = *z_pc++ write anything else
 
 t_puttoken:
-    STT z_dst INV z_dst                                           ; DO THE STOP CHECK IN ANY CASE
+    SDT z_dst INV z_dst                                           ; DO THE STOP CHECK IN ANY CASE
 t_stopcheck:
     CIZ BYTE1(source_top),z_dst+1 FCC t_stopscan
     FNE t_dictfull
@@ -537,11 +544,11 @@ TakeTwo:
     LDS 4 CPT z_pc FNE .firstfalse
     INV z_pc
     LDS 3 CPT z_pc FNE .secondfalse
-    INV z_pc LDI 1 STS 4 RTS
+    INV z_pc LDI 1 SDS 4 RTS
 .secondfalse:
     DEV z_pc                                     ; move back again
 .firstfalse:
-    LDI 0 STS 4 RTS                              ; return false
+    LDI 0 SDS 4 RTS                              ; return false
 
 ; --------------------------------------------------------------------------------------
 ; TOKENIZER PARSING ROUTINES
@@ -557,7 +564,7 @@ TakeAlNum:
     CPI 'Z' FGT .takeaout                          ; one above 'Z'
     CPI 'A' FCC .takeaout
 .takeisa:
-    STR .alptr INW .alptr INV z_pc INB .alcount      ; store the char and continue
+    SDR .alptr INW .alptr INV z_pc INB .alcount      ; store the char and continue
 .takeanloop:
     LDT z_pc                                      ; consecutive chars
     CPI 'z' FGT .takeaout
@@ -594,7 +601,7 @@ int_lsr:
     FPL intlsrpos
     NEG FPA intlslpos
 intlsrpos:
-    STZ z_count
+    SDZ z_count
 intlsrloop:
     LRZ z_A+1 RRZ z_A+0
     DEZ z_count FGT intlsrloop
@@ -606,7 +613,7 @@ int_lsl:
     FPL intlslpos
     NEG FPA intlsrpos
 intlslpos:
-    STZ z_count
+    SDZ z_count
 intlslloop:
     LLV z_A DEZ z_count FGT intlslloop
 intlsldone:
@@ -628,18 +635,18 @@ int_tostr:
     LDZ z_C+2 RL1                                           ; activate C stored in bit 7 (initially = 0)
     RLV z_C RLZ z_C+2                                       ; shift C back in and shift everything one step left
     CPI 10 FCC .int_done                                    ; 10 did not fit in => do not set bit 7 as carry
-    ADI 118 STZ z_C+2                                       ; 10 went into it => subtract 10 and set bit 7 as carry (-10 +128)
+    ADI 118 SDZ z_C+2                                       ; 10 went into it => subtract 10 and set bit 7 as carry (-10 +128)
 .int_done:
     DEZ z_count BNE .int_shift
     LDZ z_C+2 ANI 0x7f                                      ; erase a possible stored carry
-    ADI '0' STT z_strptr DEV z_strptr                       ; store remainder as char
+    ADI '0' SDT z_strptr DEV z_strptr                       ; store remainder as char
     LDZ z_C+2 RL1                                           ; restore stored carry flag
     RLV z_C                                                 ; shift in C and shift everything one step up
     RLZ z_C+2                                               ; shift C into 'remember' and shift an old carry out
     LDI 0 CPZ z_C+0 BNE .int_start                          ; prüfe nach, ob big register null enthält
     CPZ z_C+1 BNE .int_start
-    LDB .int_str CPI '-' FNE .int_out                       ; A must hold '-' for STR below
-    STT z_strptr RTS
+    LDB .int_str CPI '-' FNE .int_out                       ; A must hold '-' for SDR below
+    SDT z_strptr RTS
 .int_out:
     INV z_strptr RTS
 .int_str:  .cstr  "-32768"
@@ -654,10 +661,10 @@ PrintLongZC:
     MIZ 10,z_count
     MIV long_pow10_table,longptr
 .placeloop:
-    LDR longptr STZ z_E+0 INW longptr
-    LDR longptr STZ z_E+1 INW longptr
-    LDR longptr STZ z_E+2 INW longptr
-    LDR longptr STZ z_E+3 INW longptr
+    LDR longptr SDZ z_E+0 INW longptr
+    LDR longptr SDZ z_E+1 INW longptr
+    LDR longptr SDZ z_E+2 INW longptr
+    LDR longptr SDZ z_E+3 INW longptr
     MIZ '0',z_A+0
 .digitloop:
     LDZ z_C+3 CPZ z_E+3 FGT .subtract
@@ -700,34 +707,34 @@ PushLongLhsSpill:
     AIW 4,longptr
     CIB BYTE1(lhs_spill_end),longptr+1 BCC .store
     BNE memerror
-    CIB BYTE0(lhs_spill_end),longptr+0 FCC .store
+    CIB BYTE0(lhs_spill_end),longptr+0 BCC .store
     BNE memerror
 .store:
     MVV lhs_spill_ptr,longptr
-    LDZ z_C+0 STR longptr INW longptr
-    LDZ z_C+1 STR longptr INW longptr
-    LDZ z_C+2 STR longptr INW longptr
-    LDZ z_C+3 STR longptr INW longptr
-    LDZ z_type STR longptr
+    LDZ z_C+0 SDR longptr INW longptr
+    LDZ z_C+1 SDR longptr INW longptr
+    LDZ z_C+2 SDR longptr INW longptr
+    LDZ z_C+3 SDR longptr INW longptr
+    LDZ z_type SDR longptr
     AIV 5,lhs_spill_ptr
     RTS
 
 PopLongLhsSpill:
     SIV 5,lhs_spill_ptr
     MVV lhs_spill_ptr,longptr
-    LDR longptr STZ z_E+0 INW longptr
-    LDR longptr STZ z_E+1 INW longptr
-    LDR longptr STZ z_E+2 INW longptr
-    LDR longptr STZ z_E+3 INW longptr
-    LDR longptr STZ z_flag
+    LDR longptr SDZ z_E+0 INW longptr
+    LDR longptr SDZ z_E+1 INW longptr
+    LDR longptr SDZ z_E+2 INW longptr
+    LDR longptr SDZ z_E+3 INW longptr
+    LDR longptr SDZ z_flag
     RTS
 
 PopIntLhsToLongE:
     ; Standard convention: data on stack is [MSB, LSB] (pushed LSB first)
     ; Stack after JPS: [return_low, return_high, MSB, LSB, ...]
     ; Use LDS to read without popping; caller cleans up with PLS PLS
-    LDS 3 STZ z_E+1                                         ; read MSB from stack offset 3
-    LDS 4 STZ z_E+0                                         ; read LSB from stack offset 4
+    LDS 3 SDZ z_E+1                                         ; read MSB from stack offset 3
+    LDS 4 SDZ z_E+0                                         ; read LSB from stack offset 4
     CLV z_E+2                                               ; clear upper word
     CIZ 0,z_E+1
     FPL pop_int_lhs_long_rts
@@ -737,10 +744,10 @@ pop_int_lhs_long_rts:
     RTS
 
 PopIntLhsHiLoToLongE:
-    PLS STZ pop_int_ret+0                                   ; save return address low
-    PLS STZ pop_int_ret+1                                   ; save return address high
-    PLS STZ z_E+1                                           ; now pop actual data
-    PLS STZ z_E+0
+    PLS SDZ pop_int_ret+0                                   ; save return address low
+    PLS SDZ pop_int_ret+1                                   ; save return address high
+    PLS SDZ z_E+1                                           ; now pop actual data
+    PLS SDZ z_E+0
     CLV z_E+2
     CIZ 0,z_E+1
     FPL pop_int_hilo_long_rts
@@ -928,7 +935,7 @@ LongLsl:
     FPL longlsl_pos
     NEG FPA longasr_pos
 longlsl_pos:
-    STZ z_count
+    SDZ z_count
 longlsl_loop:
     LLQ z_C
     DEZ z_count FGT longlsl_loop
@@ -940,7 +947,7 @@ LongAsr:
     FPL longasr_pos
     NEG FPA longlsl_pos
 longasr_pos:
-    STZ z_count
+    SDZ z_count
 longasr_loop:
     LDZ z_C+3 LL1
     RRZ z_C+3
@@ -1017,7 +1024,7 @@ int_div:
     MIZ 8,z_count                           ; pre-init the shiftcounter (needs modification below)
 .divup:
     LDZ z_B+1 LL1 FMI .divloop              ; ist oberstes bit vom B schon 'ganz oben'?
-    STZ z_B+1 INZ z_count FPA .divup        ; increase number of shifts and shift upper B one step up
+    SDZ z_B+1 INZ z_count FPA .divup        ; increase number of shifts and shift upper B one step up
 .divloop:
     MVV z_A,z_C                             ; copy A to C
     LDZ z_B+0 SUV z_A+0 FCC .divcarry0
@@ -1042,14 +1049,14 @@ int_div:
 get:
     CIZ 4,z_type FEQ .getlongerr
     CIZ 2,z_type FEQ .getint
-    LDT z_sp STZ z_A+0                                      ;                       ; load char and cast to int in C-style
+    LDT z_sp SDZ z_A+0                                      ;                       ; load char and cast to int in C-style
     LL1 FCS .getminus
     CLZ z_A+1 RTS
 .getminus:
     MIZ 0xff,z_A+1 RTS
 .getint:
-    LDT z_sp STZ z_A+0                                      ; load int
-    LDT z_spi STZ z_A+1
+    LDT z_sp SDZ z_A+0                                      ; load int
+    LDT z_spi SDZ z_A+1
     RTS
 .getlongerr:
     PHSPTR error06 JPA Error
@@ -1058,23 +1065,23 @@ get:
 put:
     MIV 1,z_cnt                                             ; set element count to one in any case
     CPZ z_type FEQ .putchar
-    LDZ z_A+1 STT z_spi                                     ; store single int
+    LDZ z_A+1 SDT z_spi                                     ; store single int
 .putchar:
-    LDZ z_A+0 STT z_sp
+    LDZ z_A+0 SDT z_sp
     RTS
 
 ; Reads an element of the math stack (int or char -> int, depending on z_type) into z_B
 getB:
     CIZ 4,z_type FEQ .getBlongerr
     CIZ 2,z_type FEQ .getBint
-    LDT z_sp STZ z_B+0                                      ; load char and cast to int in C-style
+    LDT z_sp SDZ z_B+0                                      ; load char and cast to int in C-style
     LL1 FCS .getBminus
     CLZ z_B+1 RTS
 .getBminus:
     MIZ 0xff,z_B+1 RTS
 .getBint:
-    LDT z_sp STZ z_B+0                                      ; load int
-    LDT z_spi STZ z_B+1
+    LDT z_sp SDZ z_B+0                                      ; load int
+    LDT z_spi SDZ z_B+1
     RTS
 .getBlongerr:
     LDI BYTE0(error06) PHS LDI BYTE1(error06) PHS JPA Error
@@ -1091,24 +1098,24 @@ getL:
 .getLrts:
     RTS
 .getLlong:
-    LDT z_sp STZ z_C+0
-    LDT z_spi STZ z_C+1
+    LDT z_sp SDZ z_C+0
+    LDT z_spi SDZ z_C+1
     MVV z_sp,longptr
     AIW 2,longptr
-    LDR longptr STZ z_C+2 INW longptr
-    LDR longptr STZ z_C+3
+    LDR longptr SDZ z_C+2 INW longptr
+    LDR longptr SDZ z_C+3
     RTS
 
 ; writes the 32-bit value in z_C as one long scalar at z_sp
 putL:
     MIZ 4,z_type
     MIV 1,z_cnt
-    LDZ z_C+0 STT z_sp
-    LDZ z_C+1 STT z_spi
+    LDZ z_C+0 SDT z_sp
+    LDZ z_C+1 SDT z_spi
     MVV z_sp,longptr
     AIW 2,longptr
-    LDZ z_C+2 STR longptr INW longptr
-    LDZ z_C+3 STR longptr
+    LDZ z_C+2 SDR longptr INW longptr
+    LDZ z_C+3 SDR longptr
     RTS
 
 CheckLongTop:
@@ -1183,7 +1190,7 @@ SkipStmt:
     CPI 0xd1 FNE gotadvance
     AIV 5,z_pc FPA SkipStmt                                 ; hop over 32-bit const tokens too
 .gotindent:
-    NOT DEC STZ z_mind INV z_pc                             ; leaves with MEASURED and consumed indentation
+    NOT DEC SDZ z_mind INV z_pc                             ; leaves with MEASURED and consumed indentation
     CZZ z_mind,z_tind FMI SkipStmt
     RTS
 
@@ -1207,14 +1214,14 @@ getVar:
     CZZ z_vcache_sub,z_sub FNE .var_probe1
     CZZ z_vcache_top+0,z_nextvar+0 FNE .var_probe1
     CZZ z_vcache_top+1,z_nextvar+1 FNE .var_probe1
-    LDB z_vcache_ptr+1 STS 3 LDB z_vcache_ptr+0 STS 4 RTS
+    LDB z_vcache_ptr+1 SDS 3 LDB z_vcache_ptr+0 SDS 4 RTS
 .var_probe1:
     ; probe slot 1
     LDS 3 CPZ z_vcache2_id BNE .var_scan
     CZZ z_vcache2_sub,z_sub BNE .var_scan
     CZZ z_vcache2_top+0,z_nextvar+0 BNE .var_scan
     CZZ z_vcache2_top+1,z_nextvar+1 BNE .var_scan
-    LDB z_vcache2_ptr+1 STS 3 LDB z_vcache2_ptr+0 STS 4 RTS
+    LDB z_vcache2_ptr+1 SDS 3 LDB z_vcache2_ptr+0 SDS 4 RTS
 .var_scan:
     MVV z_nextvar,getptr                                    ; copy var top ptr
 .varnext:
@@ -1236,11 +1243,11 @@ getVar:
     MZZ z_vcache_sub,z_vcache2_sub
     MVV z_vcache_top,z_vcache2_top
     MVV z_vcache_ptr,z_vcache2_ptr
-    LDS 3 STZ z_vcache_id
+    LDS 3 SDZ z_vcache_id
     MZZ z_sub,z_vcache_sub
     MVV z_nextvar,z_vcache_top
     MVV getptr,z_vcache_ptr
-    STS 3 LDZ getptr+0 STS 4                                ; put var ptr to type on stack
+    SDS 3 LDZ getptr+0 SDS 4                                ; put var ptr to type on stack
     RTS
 
 ; search call dictionary for *latest* match
@@ -1251,9 +1258,9 @@ getCall:
     LDS 3 CPZ z_ccache_id FNE .call_scan
     CZZ z_ccache_top+0,z_nextcall+0 FNE .call_scan
     CZZ z_ccache_top+1,z_nextcall+1 FNE .call_scan
-    LDB z_ccache_pc+1 STS 3 LDB z_ccache_pc+0 STS 4 RTS
+    LDB z_ccache_pc+1 SDS 3 LDB z_ccache_pc+0 SDS 4 RTS
 .call_scan:
-    LDS 3 STZ z_ccache_id                                   ; save call_id for cache + scan comparison
+    LDS 3 SDZ z_ccache_id                                   ; save call_id for cache + scan comparison
     MVV z_nextcall,z_ccache_top                             ; save z_nextcall snapshot for cache
     MVV z_nextcall,getptr                                   ; copy call top ptr
 .callnext:
@@ -1262,10 +1269,10 @@ getCall:
     PHSPTR error01 JPA Error ; error undefined call
 .callokay:
     LDZ z_ccache_id CPT getptr FNE .callnext                 ; compare saved call_id vs entry
-    INV getptr LDT getptr STS 4                             ; put call jump address on stack
-    INV getptr LDT getptr STS 3
+    INV getptr LDT getptr SDS 4                             ; put call jump address on stack
+    INV getptr LDT getptr SDS 3
     ; refresh cache value with resolved PC
-    LDS 3 STZ z_ccache_pc+1 LDS 4 STZ z_ccache_pc+0
+    LDS 3 SDZ z_ccache_pc+1 LDS 4 SDZ z_ccache_pc+0
     RTS
 
 ; --------------------------------------------------------------------------------------
@@ -1279,17 +1286,17 @@ Factor:
     CPI 0xd0 FNE fac_next2                                  ; TN_INT_CONST
     INV z_pc MIZ 2,z_type
     MIV 1,z_cnt                                             ; single int
-    LDT z_pc STT z_sp INV z_pc
-    LDT z_pc STT z_spi INV z_pc
+    LDT z_pc SDT z_sp INV z_pc
+    LDT z_pc SDT z_spi INV z_pc
     RTS
 
 fac_next2:
     CPI 0xd1 FNE fac_next2b                                 ; TN_LONG_CONST
     INV z_pc
-    LDT z_pc STZ z_C+0 INV z_pc
-    LDT z_pc STZ z_C+1 INV z_pc
-    LDT z_pc STZ z_C+2 INV z_pc
-    LDT z_pc STZ z_C+3 INV z_pc
+    LDT z_pc SDZ z_C+0 INV z_pc
+    LDT z_pc SDZ z_C+1 INV z_pc
+    LDT z_pc SDZ z_C+2 INV z_pc
+    LDT z_pc SDZ z_C+3 INV z_pc
     JPS putL JPS CheckLongTop
     RTS
 
@@ -1308,16 +1315,16 @@ fac_next3:
 fac_isvar:
     INV z_pc                                                ; consume, either 'V' or '&' was pushed above
     LDT z_pc PHS PHS INV z_pc JPS getVar                    ; get & consume variable ID, push v->type on stack
-    PLS STZ facptr+1 PLS STZ facptr+0                       ; load var item onto stack:
+    PLS SDZ facptr+1 PLS SDZ facptr+0                       ; load var item onto stack:
     LDT facptr PHS INV facptr                               ; ->type
     LDT facptr PHS INV facptr LDT facptr PHS INV facptr     ; ->cnt
     LDT facptr PHS INV facptr LDT facptr PHS                ; ->ptr
     CIT '[',z_pc BNE fac_fullvar                            ; [|] OPERATOR PRESENT?
 
 ; PARSE [|] OPERATOR
-    INV facptr LDT facptr STZ slice_max+0 INV facptr LDT facptr STZ slice_max+1
+    INV facptr LDT facptr SDZ slice_max+0 INV facptr LDT facptr SDZ slice_max+1
     CLZ slice_start+0 CLZ slice_start+1                     ; default start = 0
-    LDS 4 STZ slice_count+0 LDS 3 STZ slice_count+1         ; default count = ->cnt
+    LDS 4 SDZ slice_count+0 LDS 3 SDZ slice_count+1         ; default count = ->cnt
     INV z_pc CIT '|',z_pc FNE fac_nopipe                    ; consume [, parse for |
     INV z_pc CIT ']',z_pc FEQ fac_closed
     JPS Expr JPS get
@@ -1353,7 +1360,7 @@ fac_closed:
 ; copies variable elements onto the math stack
 fac_passed:
     LDS 6 CPI '&' BEQ fac_elemref                           ; ELEMENTS [|] OF VARIABLE
-    LDS 5 STZ z_type                                        ; z_type = vp->type
+    LDS 5 SDZ z_type                                        ; z_type = vp->type
     MVV slice_count,z_A
     MVV slice_count,z_cnt                                   ; z_A = anz, z_cnt = anz
     MVV slice_start,z_B
@@ -1361,7 +1368,7 @@ fac_passed:
     JPS ScaleBByType
     JPS ScaleAByType                                        ; scale start/count by element width
 fac_elembyte:
-    LDS 2 STB fac_src0+0 LDS 1 STB fac_src0+1               ; source address = ->ptr + startindex * ->type
+    LDS 2 SDB fac_src0+0 LDS 1 SDB fac_src0+1               ; source address = ->ptr + startindex * ->type
     LDZ z_B+1 AD.B fac_src0+1 LDZ z_B+0 ADW fac_src0
     MZB z_sp+0,fac_dst0+0 MZB z_sp+1,fac_dst0+1             ; z_sp = destination
 fac_loop0:
@@ -1392,13 +1399,13 @@ fac_elemrts:
 ; copies the full variable onto the math stack (faster)
 fac_fullvar:
     LDS 6 CPI '&' FEQ fac_fullref                           ; FULL VAR
-    LDS 4 STZ z_cnt+0 STZ z_A+0                             ; set z_cnt, use z_A as byte counter
-    LDS 3 STZ z_cnt+1 STZ z_A+1
+    LDS 4 SDZ z_cnt+0 SDZ z_A+0                             ; set z_cnt, use z_A as byte counter
+    LDS 3 SDZ z_cnt+1 SDZ z_A+1
 fac_nosingle:
-    LDS 5 STZ z_type CPI 1 FEQ fac_fullchar                 ; set z_type
+    LDS 5 SDZ z_type CPI 1 FEQ fac_fullchar                 ; set z_type
     JPS ScaleAByType
 fac_fullchar:
-    LDS 2 STB fac_src+0 LDS 1 STB fac_src+1                 ; set src data pointer
+    LDS 2 SDB fac_src+0 LDS 1 SDB fac_src+1                 ; set src data pointer
     MZB z_sp+0,fac_dst+0 MZB z_sp+1,fac_dst+1               ; set dst to top of math stack
 fac_loop:
     DEV z_A FCC fac_endfull
@@ -1412,9 +1419,9 @@ fac_endfull:
     FNE memerror
 fac_fullref:
     MIZ 2,z_type                                            ; FULL REFERENCE
-    MIZ 1,z_refset STZ z_cnt+0 CLZ z_cnt+1                  ; set type=2, cnt=1
-    LDS 4 STZ z_refcnt+0 LDS 3 STZ z_refcnt+1               ; ->cnt to z_refcnt, z_refset=1
-    LDS 2 STT z_sp LDS 1 STT z_spi                          ; put ->ptr onto math stack
+    MIZ 1,z_refset SDZ z_cnt+0 CLZ z_cnt+1                  ; set type=2, cnt=1
+    LDS 4 SDZ z_refcnt+0 LDS 3 SDZ z_refcnt+1               ; ->cnt to z_refcnt, z_refset=1
+    LDS 2 SDT z_sp LDS 1 SDT z_spi                          ; put ->ptr onto math stack
 fac_fullrts:
     LDI 6 AD.B 0xffff RTS
 
@@ -1424,7 +1431,7 @@ fac_next4:
     MZB z_sp+0,fac_p+0 MZB z_sp+1,fac_p+1
 fac_while:
     LDT z_pc CPI '"' BEQ fac_endstr
-    STB @fac_p: 0xffff
+    SDB @fac_p: 0xffff
     INV z_pc INW fac_p INV z_cnt JPA fac_while
 fac_endstr:
     MIR 0,fac_p                                             ; write 0-termination byte
@@ -1469,7 +1476,7 @@ fac_castint:
     LDZ z_cnt+0 ANI 0xfe ORZ z_cnt+1
     CPI 0 FNE fac_casttypeerr
     CIZ 1,z_type FNE fac_castintdone
-    LDT z_sp LL1 LDI 0 RL1 NEG STT z_spi                    ; sign-extend char to int
+    LDT z_sp LL1 LDI 0 RL1 NEG SDT z_spi                    ; sign-extend char to int
 fac_castintdone:
     MIZ 2,z_type
     CLZ z_refset
@@ -1502,13 +1509,13 @@ fac_lenof:
     INV z_pc                                                ; consume V
     LDT z_pc PHS PHS INV z_pc                               ; push var_id, consume
     JPS getVar                                              ; returns ptr to ->type on stack
-    PLS STZ facptr+1 PLS STZ facptr+0                       ; pop var ptr into facptr
+    PLS SDZ facptr+1 PLS SDZ facptr+0                       ; pop var ptr into facptr
     PLS                                                     ; recover offset into A
-    ADZ facptr+0 STZ facptr+0                               ; facptr += offset
-    LDI 0 ACZ facptr+1 STZ facptr+1
-    LDT facptr STT z_sp                                     ; read lsb → expression stack
+    ADZ facptr+0 SDZ facptr+0                               ; facptr += offset
+    LDI 0 ACZ facptr+1 SDZ facptr+1
+    LDT facptr SDT z_sp                                     ; read lsb → expression stack
     INV facptr
-    LDT facptr STT z_spi                                    ; read msb → expression stack
+    LDT facptr SDT z_spi                                    ; read msb → expression stack
     JPS AssertCRound                                        ; consume )
     MIZ 2,z_type                                            ; result type = int
     MIV 1,z_cnt                                             ; cnt = 1
@@ -1542,7 +1549,7 @@ Term:
     LDZ z_B+0 ORZ z_B+1 CPI 0 FNE .term_divokay
     LDI BYTE0(error22) PHS LDI BYTE1(error22) PHS JPA Error ; error divide by 0
 .term_divokay:
-    PLS STZ z_A+1 PLS STZ z_A+0                             ; pull A
+    PLS SDZ z_A+1 PLS SDZ z_A+0                             ; pull A
     JPS int_div FPA .term_reuse
 .term_longdiv_rhs:
     JPS PopIntLhsHiLoToLongE
@@ -1562,7 +1569,7 @@ Term:
     JPS Factor
     CIZ 4,z_type FEQ .term_longmul_rhs
     JPS getB
-    PLS STZ z_A+1 PLS STZ z_A+0                             ; pull A
+    PLS SDZ z_A+1 PLS SDZ z_A+0                             ; pull A
     JPS int_mul
     FPA .term_reuse
 .term_longmul_rhs:
@@ -1577,7 +1584,7 @@ Term:
     JPS LongMulStore
     FPA .term_while
 .term_reuse:
-    LDZ z_A+0 STT z_sp LDZ z_A+1 STT z_spi                  ; store result as int
+    LDZ z_A+0 SDT z_sp LDZ z_A+1 SDT z_spi                  ; store result as int
     CLZ z_refset MIZ 2,z_type
     MIV 1,z_cnt
     FPA .term_while
@@ -1600,7 +1607,7 @@ base_minus:
 base_minus_int:
     JPS get NEV z_A
 base_reuse:
-    STT z_spi LDZ z_A+0 STT z_sp        ; assumes MSB already in A
+    SDT z_spi LDZ z_A+0 SDT z_sp        ; assumes MSB already in A
     CLZ z_refset MIZ 2,z_type
     MIV 1,z_cnt
 base_while:
@@ -1718,7 +1725,7 @@ rele_neq:
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_neq_rhslong
     JPS getB
-    PLS CPZ z_B+1 FNE int_true_pop
+    PLS CPZ z_B+1 BNE int_true_pop
     PLS CPZ z_B+0 BNE int_true
     JPA int_false
 rele_neq_rhslong:
@@ -1811,7 +1818,7 @@ rele_gt_lhslong:
 int_true:
     MIV 0xffff,z_A
 rele_reuse:
-    LDZ z_A+0 STT z_sp LDZ z_A+1 STT z_spi     ; store result as int
+    LDZ z_A+0 SDT z_sp LDZ z_A+1 SDT z_spi     ; store result as int
     CLZ z_refset MIZ 2,z_type
     MIV 1,z_cnt
     JPA rele_while
@@ -1835,7 +1842,7 @@ expr_not:
 expr_not_int:
     JPS get NOV z_A
 expr_reuse:
-    LDZ z_A+0 STT z_sp LDZ z_A+1 STT z_spi ; store result as int
+    LDZ z_A+0 SDT z_sp LDZ z_A+1 SDT z_spi ; store result as int
     CLZ z_refset MIZ 2,z_type
     MIV 1,z_cnt
 expr_while:
@@ -1845,7 +1852,7 @@ expr_while:
     CIZ 4,z_type BEQ expr_longand_lhs
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS RelExpr
-    CIZ 4,z_type FEQ expr_longand_rhs
+    CIZ 4,z_type BEQ expr_longand_rhs
     JPS get
     PLS AN.Z z_A+1 PLS AN.Z z_A+0
     JPA expr_reuse
@@ -1911,7 +1918,7 @@ expr_shiftl:
     JPS RelExpr
     CIZ 4,z_type FEQ expr_longlsl_rhs
     JPS getB
-    PLS STZ z_A+1 PLS STZ z_A+0
+    PLS SDZ z_A+1 PLS SDZ z_A+0
     JPS int_lsl
     JPA expr_reuse
 expr_longlsl_rhs:
@@ -1941,7 +1948,7 @@ expr_shiftr:
     JPS RelExpr
     CIZ 4,z_type FEQ expr_longasr_rhs
     JPS getB
-    PLS STZ z_A+1 PLS STZ z_A+0
+    PLS SDZ z_A+1 PLS SDZ z_A+0
     JPS int_lsr
     JPA expr_reuse
 expr_longasr_rhs:
@@ -1987,8 +1994,8 @@ compwhile:
     LDI BYTE0(error06) PHS LDI BYTE1(error06) PHS JPA Error ; type mismatch
 comptypeok:
     PLS AD.Z z_cnt+1 PLS ADV z_cnt                          ; add up to total element count
-    PLS STZ z_sp+1                                          ; restore stack state
-    PLS STZ z_sp+0
+    PLS SDZ z_sp+1                                          ; restore stack state
+    PLS SDZ z_sp+0
     MVV z_sp,z_spi
     INV z_spi
     FPA compwhile
@@ -2002,7 +2009,7 @@ comp_rts:
 TypedCompExpr:
     LDZ tcomp_type PHS                                      ; preserve requested type across nested calls/TypedCompExpr
     JPS CompExpr                                            ; parses compound expression of any type
-    PLS STZ tcomp_type
+    PLS SDZ tcomp_type
     MZZ z_type,z_flag                                       ; remember source type before any widening/narrowing
     LDZ tcomp_type CPZ z_type BEQ .tcomp_rts                 ; matching types -> do nothing, else enforce type
     LDZ z_cnt+0 ANI 0xfe ORZ z_cnt+1                        ; conversions are scalar-only
@@ -2035,7 +2042,7 @@ TypedCompExpr:
     CIZ 2,tcomp_type FNE .tcomp_tolong                       ; desired type int?
     CIB 4,z_flag FEQ .tcomperror                             ; implicit long -> int narrowing is not allowed
     CIB 1,z_flag FNE .tcomp_rts
-    LDT z_sp LL1 LDI 0 RL1 NEG STT z_spi                    ; cast char -> int in C-style w/o branching
+    LDT z_sp LL1 LDI 0 RL1 NEG SDT z_spi                    ; cast char -> int in C-style w/o branching
     MIZ 2,z_type
     RTS
 .tcomp_tolong:
@@ -2067,10 +2074,10 @@ CallStmt:
     PHSPTR error05 JPA Error    ; error invalid expr
 .callint:
     INV z_pc
-    LDT z_pc STB .callto+0 INV z_pc
-    LDT z_pc STB .callto+1 INV z_pc
+    LDT z_pc SDB .callto+0 INV z_pc
+    LDT z_pc SDB .callto+1 INV z_pc
     JPS @.callto: 0xffff                                        ; jump to subroutine
-    STZ 0xff                                                   ; store accumulator SysReg
+    SDZ 0xff                                                   ; store accumulator SysReg
     RTS
 
 IfStmt:
@@ -2086,7 +2093,7 @@ if_while:
     LDS 1 CPI 0 FEQ if_2_else
     JPS SkipStmt FPA if_while
 if_2_else:
-    JPS Expr JPS ScalarTruthy STS 1
+    JPS Expr JPS ScalarTruthy SDS 1
     CPI 0 BEQ if_3_else
     JPS Block JPA if_while
 if_3_else:
@@ -2117,8 +2124,8 @@ printmore:
 printnext:
     DEV z_B FCC printmore                                      ; first test for zero elements
 printnext2:
-    LDT z_D STZ z_A+0 INV z_D                                  ; read out next int
-    LDT z_D STZ z_A+1 INV z_D
+    LDT z_D SDZ z_A+0 INV z_D                                  ; read out next int
+    LDT z_D SDZ z_A+1 INV z_D
     JPS int_tostr                                              ; convert z_A to string
     LDZ z_strptr+0 PHS LDZ z_strptr+1 PHS JPS emit_str PLS PLS
     DEV z_B FCC printmore
@@ -2129,10 +2136,10 @@ printlongs:
 printlongnext:
     DEV z_B FCC printmore
 printlongnext2:
-    LDT z_D STZ z_C+0 INV z_D
-    LDT z_D STZ z_C+1 INV z_D
-    LDT z_D STZ z_C+2 INV z_D
-    LDT z_D STZ z_C+3 INV z_D
+    LDT z_D SDZ z_C+0 INV z_D
+    LDT z_D SDZ z_C+1 INV z_D
+    LDT z_D SDZ z_C+2 INV z_D
+    LDT z_D SDZ z_C+3 INV z_D
     JPS PrintLongZC
     DEV z_B FCC printmore
     LDI '_' JAS emit_char FPA printlongnext2
@@ -2165,8 +2172,8 @@ emit_str:
     JPS _PrintPtr PLS PLS
     CIZ 0,z_serial FEQ .done                                   ; z_serial == 0 → done
 .ser:
-    LDS 4 STZ pop_int_ret+0                                    ; string LSB into temp pointer
-    LDS 3 STZ pop_int_ret+1                                    ; string MSB into temp pointer
+    LDS 4 SDZ pop_int_ret+0                                    ; string LSB into temp pointer
+    LDS 3 SDZ pop_int_ret+1                                    ; string MSB into temp pointer
     FPA .sentry
 .sloop:
     OUT JPS _SerialWait
@@ -2206,7 +2213,7 @@ fun_depthok:
     LDZ z_tind PHS CLZ z_tind
     JPS AssertORound                                        ; consume caller (
     LDZ z_pc+0 PHS LDZ z_pc+1 PHS                           ; store z_pc -> args
-    LDS 11 STZ z_B+0 LDS 10 STZ z_B+1                       ; callee params -> z_B
+    LDS 11 SDZ z_B+0 LDS 10 SDZ z_B+1                       ; callee params -> z_B
     LDZ z_fun_argpc+0 PHS LDZ z_fun_argpc+1 PHS             ; preserve caller cursors (re-entrant calls)
     LDZ z_fun_parpc+0 PHS LDZ z_fun_parpc+1 PHS
     MVV z_pc,z_fun_argpc
@@ -2224,14 +2231,14 @@ fun_while:
 fun_typeerr:
     LDI BYTE0(error17) PHS LDI BYTE1(error17) PHS JPA Error ; error Invalid parameter
 fun_typeok:
-    SUI '0' STZ z_tmp_type INV z_pc                         ; park parsed type in temp, consume type
+    SUI '0' SDZ z_tmp_type INV z_pc                         ; park parsed type in temp, consume type
     LDT z_pc CPI '&' BNE fun_plainvar                       ; reference & variable
     INV z_pc                                                ; consume &
     CIT 'V',z_pc FNE fun_typeerr
     INV z_pc                                                ; consume V
-    LDT z_pc STT z_nextvar INV z_pc                         ; consume & store ->id
-    INV z_nextvar LDZ z_sub INC STT z_nextvar               ; store ->sub
-    INV z_nextvar LDZ z_tmp_type STT z_nextvar              ; store temp type ->type
+    LDT z_pc SDT z_nextvar INV z_pc                         ; consume & store ->id
+    INV z_nextvar LDZ z_sub INC SDT z_nextvar               ; store ->sub
+    INV z_nextvar LDZ z_tmp_type SDT z_nextvar              ; store temp type ->type
     AIV 7,z_nextvar                                         ; goto new top of vars
     MVV z_pc,z_fun_parpc                                    ; z_pc -> par
     MVV z_fun_argpc,z_pc                                    ; arg -> z_pc
@@ -2243,24 +2250,24 @@ fun_typeok:
 fun_isvar:
     INV z_pc                                                ; consume V
     LDT z_pc PHS PHS INV z_pc JPS getVar                    ; consume and push ID
-    PLS STZ z_refptr+1 PLS STZ z_refptr+0                   ; return pointer to ref variable *type*
+    PLS SDZ z_refptr+1 PLS SDZ z_refptr+0                   ; return pointer to ref variable *type*
     SIV 7,z_nextvar                                         ; down to ->type
     LDT z_refptr CPT z_nextvar FNE fun_typeerr              ; error Reference type mismatch
     INV z_nextvar INV z_refptr                              ; advance to ->cnt
-    LDT z_refptr STT z_nextvar INV z_nextvar INV z_refptr   ; -> cnt
-    LDT z_refptr STT z_nextvar INV z_nextvar INV z_refptr
-    LDT z_refptr STT z_nextvar INV z_nextvar INV z_refptr   ; -> ptr
-    LDT z_refptr STT z_nextvar INV z_nextvar INV z_refptr
-    LDT z_refptr STT z_nextvar INV z_nextvar INV z_refptr   ; -> max
-    LDT z_refptr STT z_nextvar INV z_nextvar INV z_refptr
+    LDT z_refptr SDT z_nextvar INV z_nextvar INV z_refptr   ; -> cnt
+    LDT z_refptr SDT z_nextvar INV z_nextvar INV z_refptr
+    LDT z_refptr SDT z_nextvar INV z_nextvar INV z_refptr   ; -> ptr
+    LDT z_refptr SDT z_nextvar INV z_nextvar INV z_refptr
+    LDT z_refptr SDT z_nextvar INV z_nextvar INV z_refptr   ; -> max
+    LDT z_refptr SDT z_nextvar INV z_nextvar INV z_refptr
     FPA fun_whileon
 
 fun_plainvar:
     CPI 'V' BNE fun_typeerr
     INV z_pc                                                ; consume 'V'
-    LDT z_pc STT z_nextvar INV z_pc                         ; store & consume ->id
-    INV z_nextvar LDZ z_sub INC STT z_nextvar               ; store ->sub
-    INV z_nextvar LDZ z_tmp_type STT z_nextvar              ; store temp type ->type
+    LDT z_pc SDT z_nextvar INV z_pc                         ; store & consume ->id
+    INV z_nextvar LDZ z_sub INC SDT z_nextvar               ; store ->sub
+    INV z_nextvar LDZ z_tmp_type SDT z_nextvar              ; store temp type ->type
     AIV 7,z_nextvar                                         ; goto new top of vars
     MVV z_pc,z_fun_parpc                                    ; z_pc -> par
     MVV z_fun_argpc,z_pc                                    ; arg -> z_pc
@@ -2270,12 +2277,12 @@ fun_plainvar:
     MZZ z_tmp_type,tcomp_type
     JPS TypedCompExpr                                       ; request with type again
     SIV 6,z_nextvar                                         ; go down to ->cnt
-    LDZ z_cnt+0 STT z_nextvar INV z_nextvar                 ; ->cnt
-    LDZ z_cnt+1 STT z_nextvar INV z_nextvar
-    LDZ z_sp+0 STT z_nextvar INV z_nextvar                  ; ->ptr
-    LDZ z_sp+1 STT z_nextvar INV z_nextvar
-    LDZ z_cnt+0 STT z_nextvar INV z_nextvar                 ; ->max
-    LDZ z_cnt+1 STT z_nextvar INV z_nextvar
+    LDZ z_cnt+0 SDT z_nextvar INV z_nextvar                 ; ->cnt
+    LDZ z_cnt+1 SDT z_nextvar INV z_nextvar
+    LDZ z_sp+0 SDT z_nextvar INV z_nextvar                  ; ->ptr
+    LDZ z_sp+1 SDT z_nextvar INV z_nextvar
+    LDZ z_cnt+0 SDT z_nextvar INV z_nextvar                 ; ->max
+    LDZ z_cnt+1 SDT z_nextvar INV z_nextvar
     MZZ tcomp_type,z_type
     JPS ScaleCountByType
     AVV z_cnt,z_sp                                          ; z_sp += z_cnt * z_type
@@ -2290,17 +2297,17 @@ fun_whileex:
     INV z_pc                                                ; consume callee's param )
     INZ z_sub JPS FastBlock DEZ z_sub                       ; jump into callee's function block
     MVV z_fun_argpc,z_B                                     ; keep caller arg cursor
-    PLS STZ z_fun_parpc+1 PLS STZ z_fun_parpc+0
-    PLS STZ z_fun_argpc+1 PLS STZ z_fun_argpc+0             ; restore outer call cursors
+    PLS SDZ z_fun_parpc+1 PLS SDZ z_fun_parpc+0
+    PLS SDZ z_fun_argpc+1 PLS SDZ z_fun_argpc+0             ; restore outer call cursors
     PLS PLS                                                 ; discard stacked caller-arg cursor copy
     MVV z_B,z_pc                                            ; back to caller args
     JPS AssertCRound                                        ; consume caller's ')' to reach next statement
-    PLS STZ z_tind
-    PLS STZ z_sp+1
-    PLS STZ z_sp+0
+    PLS SDZ z_tind
+    PLS SDZ z_sp+1
+    PLS SDZ z_sp+0
     MVV z_sp,z_spi
     INV z_spi
-    PLS STZ z_nextvar+1 PLS STZ z_nextvar+0
+    PLS SDZ z_nextvar+1 PLS SDZ z_nextvar+0
     CIZ 0,z_halt FEQ fun_nohalt
     LDI 0xfb AN.Z z_halt                                    ; clear RETURN flag
     LDZ z_cnt+0 ORZ z_cnt+1 CPI 0 FEQ fun_rts
@@ -2326,10 +2333,10 @@ DefStmt:
     CIZ 0,z_sub BNE deferror
     CIZ 0,z_mind BNE deferror
     INV z_pc                                                ; consume TN_CALL
-    LDT z_pc STT z_nextcall INV z_pc INV z_nextcall         ; consume and store call ID
+    LDT z_pc SDT z_nextcall INV z_pc INV z_nextcall         ; consume and store call ID
     JPS AssertORound                                        ; consume (
-    LDZ z_pc+0 STT z_nextcall INV z_nextcall                ; store PC of call
-    LDZ z_pc+1 STT z_nextcall INV z_nextcall
+    LDZ z_pc+0 SDT z_nextcall INV z_nextcall                ; store PC of call
+    LDZ z_pc+1 SDT z_nextcall INV z_nextcall
     JPS SkipStmt
     RTS
 deferror:
@@ -2347,12 +2354,12 @@ ass_element:
 ass_operator:
     LDT z_pc CPI '=' BNE ass_fastaddsub
     INV z_pc                                                ; consume =
-    LDS 6 STZ assptr+0 LDS 5 STZ assptr+1                   ; vp->type
-    LDT assptr STZ tcomp_type                               ; request typed comp-expr (now z_type = vp->type)
+    LDS 6 SDZ assptr+0 LDS 5 SDZ assptr+1                   ; vp->type
+    LDT assptr SDZ tcomp_type                               ; request typed comp-expr (now z_type = vp->type)
     JPS TypedCompExpr
     PLS CPI 0xff FEQ ass_nooffset                           ; pull and test offset MSB
-    STB ass_dst+1 STZ z_A+1                                 ; offset -> ass_dst, z_A
-    PLS STB ass_dst+0 STZ z_A+0
+    SDB ass_dst+1 SDZ z_A+1                                 ; offset -> ass_dst, z_A
+    PLS SDB ass_dst+0 SDZ z_A+0
     AVV z_cnt,z_A                                           ; RANGE SAFETY-CHECK 1: z_A = z_cnt + offset
     CIZ 1,z_type FEQ ass_typedone
     MWV ass_dst,z_B
@@ -2361,11 +2368,11 @@ ass_operator:
     MZB z_B+0,ass_dst+0
     MZB z_B+1,ass_dst+1
 ass_typedone:
-    LDS 4 STZ assptr+0 LDS 3 STZ assptr+1                   ; goto vp->type
+    LDS 4 SDZ assptr+0 LDS 3 SDZ assptr+1                   ; goto vp->type
     AIV 3,assptr LDT assptr ADW ass_dst                     ; ass_dst = vp->ptr + offset * vp->type
     INV assptr LDT assptr AD.B ass_dst+1
-    INV assptr LDT assptr STZ z_B+0                         ; RANGE SAFETY-CHECK 2: z_B = ->max
-    INV assptr LDT assptr STZ z_B+1
+    INV assptr LDT assptr SDZ z_B+0                         ; RANGE SAFETY-CHECK 2: z_B = ->max
+    INV assptr LDT assptr SDZ z_B+1
     LDZ z_A+1 SU.Z z_B+1 FCC ass_indexerr                   ; ->max - (z_cnt + offset) >= 0 ? -> okay!
     LDZ z_A+0 SUV z_B FCC ass_indexerr
     JPA ass_copy
@@ -2374,13 +2381,13 @@ ass_indexerr:
     JPA Error
 ass_nooffset:
     PLS                                                     ; discard no-offset LSB
-    LDS 4 STZ assptr+0 LDS 3 STZ assptr+1                   ; goto vp->type
-    INV assptr LDZ z_cnt+0 STT assptr                       ; z_cnt -> vp->cnt
-    INV assptr LDZ z_cnt+1 STT assptr
-    INV assptr LDT assptr STB ass_dst+0                     ; ->ptr
-    INV assptr LDT assptr STB ass_dst+1
-    INV assptr LDT assptr STZ z_A+0                         ; ->max into z_A for RANGE SAFETY-CHECK WHOLE
-    INV assptr LDT assptr STZ z_A+1
+    LDS 4 SDZ assptr+0 LDS 3 SDZ assptr+1                   ; goto vp->type
+    INV assptr LDZ z_cnt+0 SDT assptr                       ; z_cnt -> vp->cnt
+    INV assptr LDZ z_cnt+1 SDT assptr
+    INV assptr LDT assptr SDB ass_dst+0                     ; ->ptr
+    INV assptr LDT assptr SDB ass_dst+1
+    INV assptr LDT assptr SDZ z_A+0                         ; ->max into z_A for RANGE SAFETY-CHECK WHOLE
+    INV assptr LDT assptr SDZ z_A+1
     LDZ z_cnt+1 SU.Z z_A+1 FCC ass_idxwhole_err             ; ->max - z_cnt >= 0 means okay
     LDZ z_cnt+0 SUV z_A FCC ass_idxwhole_err
     JPS ScaleCountByType                                    ; reuse z_cnt as byte counter
@@ -2398,7 +2405,7 @@ ass_rts:
     RTS
 
 ass_fastaddsub:
-    STZ z_tmp_fastop INV z_pc                               ; store fast op, consume += / -= token
+    SDZ z_tmp_fastop INV z_pc                               ; store fast op, consume += / -= token
     LDT z_pc CPI '+' FEQ ass_fastconstsign
     CPI '-' FNE ass_fastconst
     INV z_pc                                                ; consume unary minus on constant rhs
@@ -2413,10 +2420,10 @@ ass_fastconstsign:
 ass_fastconst:
     CIT 0xd0,z_pc BNE ass_error                             ; TN_INT_CONST only
     INV z_pc
-    LDS 6 STZ assptr+0 LDS 5 STZ assptr+1                   ; vp->type
-    LDT assptr STZ z_tmp_type
+    LDS 6 SDZ assptr+0 LDS 5 SDZ assptr+1                   ; vp->type
+    LDT assptr SDZ z_tmp_type
     PLS CPI 0xff FEQ ass_nooffa
-    STZ z_A+1 PLS STZ z_A+0                                 ; z_A = offset
+    SDZ z_A+1 PLS SDZ z_A+0                                 ; z_A = offset
     CIZ 1,z_tmp_type FEQ ass_achar                          ; char: offset stays as-is
     LLV z_A                                                 ; offset x 2 (int or first shift for long)
     CIZ 4,z_tmp_type FNE ass_achar
@@ -2430,35 +2437,35 @@ ass_nooffa:
     INV assptr                                              ; goto ->cnt
     MIT 1,assptr INV assptr                                 ; ->cnt = 1
     MIT 0,assptr INV assptr
-    LDT assptr STZ z_A+0 INV assptr                         ; z_A = ->ptr
-    LDT assptr STZ z_A+1
+    LDT assptr SDZ z_A+0 INV assptr                         ; z_A = ->ptr
+    LDT assptr SDZ z_A+1
 ass_offaset:
     CIZ 1,z_tmp_type FEQ ass_aachar                         ; char path
     CIZ 4,z_tmp_type BEQ ass_aalong                         ; long path
-    LDT z_A STZ z_B+0 INV z_A                               ; int path: load 2 bytes
-    LDT z_A STZ z_B+1
+    LDT z_A SDZ z_B+0 INV z_A                               ; int path: load 2 bytes
+    LDT z_A SDZ z_B+1
     CIZ 'a',z_tmp_fastop FNE ass_fsubint
     LDT z_pc ADV z_B INV z_pc                               ; add fast int
-    LDT z_pc AD.Z z_B+1 STT z_A INV z_pc
-    DEV z_A LDZ z_B+0 STT z_A RTS
+    LDT z_pc AD.Z z_B+1 SDT z_A INV z_pc
+    DEV z_A LDZ z_B+0 SDT z_A RTS
 ass_fsubint:
     CIZ 's',z_tmp_fastop BNE ass_error
     LDT z_pc SUV z_B INV z_pc                               ; sub fast int
-    LDT z_pc SU.Z z_B+1 STT z_A INV z_pc
-    DEV z_A LDZ z_B+0 STT z_A RTS
+    LDT z_pc SU.Z z_B+1 SDT z_A INV z_pc
+    DEV z_A LDZ z_B+0 SDT z_A RTS
 ass_aachar:
     CIZ 'a',z_tmp_fastop FNE ass_fsubchar
-    LDT z_A ADT z_pc STT z_A                                ; add fast char
+    LDT z_A ADT z_pc SDT z_A                                ; add fast char
     AIV 2,z_pc RTS
 ass_fsubchar:
     CIZ 's',z_tmp_fastop BNE ass_error
-    LDT z_A SUT z_pc STT z_A                                ; sub fast char
+    LDT z_A SUT z_pc SDT z_A                                ; sub fast char
     AIV 2,z_pc RTS
 ass_aalong:
-    LDT z_A STZ z_C+0 INV z_A                               ; load 4 bytes from [z_A] into z_C
-    LDT z_A STZ z_C+1 INV z_A
-    LDT z_A STZ z_C+2 INV z_A
-    LDT z_A STZ z_C+3
+    LDT z_A SDZ z_C+0 INV z_A                               ; load 4 bytes from [z_A] into z_C
+    LDT z_A SDZ z_C+1 INV z_A
+    LDT z_A SDZ z_C+2 INV z_A
+    LDT z_A SDZ z_C+3
     CIZ 'a',z_tmp_fastop FNE ass_fsublong
     LDT z_pc ADV z_C INV z_pc                               ; add const LSB to z_C+0
     LDT z_pc AD.Z z_C+1 INV z_pc                            ; add const MSB + carry to z_C+1
@@ -2472,10 +2479,10 @@ ass_fsublong:
     LDI 0 SU.Z z_C+2                                        ; propagate borrow
     LDI 0 SU.Z z_C+3                                        ; propagate borrow
 ass_storelong:
-    LDZ z_C+3 STT z_A DEV z_A                               ; store 4 bytes back (z_A points to byte 3)
-    LDZ z_C+2 STT z_A DEV z_A
-    LDZ z_C+1 STT z_A DEV z_A
-    LDZ z_C+0 STT z_A RTS
+    LDZ z_C+3 SDT z_A DEV z_A                               ; store 4 bytes back (z_A points to byte 3)
+    LDZ z_C+2 SDT z_A DEV z_A
+    LDZ z_C+1 SDT z_A DEV z_A
+    LDZ z_C+0 SDT z_A RTS
 ass_error:
     LDI BYTE0(error05) PHS LDI BYTE1(error05) PHS JPA Error ; error Invalid assign
 ; 'type' token was just consumed, now expect a TN_VAR and it's identifier
@@ -2485,14 +2492,14 @@ VarDefinition:
     CIT 'V',z_pc FEQ var_okay
     LDI BYTE0(error01) PHS LDI BYTE1(error01) PHS JPA Error ; error Expecting an identifier
 var_okay:
-    INV z_pc LDT z_pc STT z_nextvar                         ; consume 'V', read & store id
+    INV z_pc LDT z_pc SDT z_nextvar                         ; consume 'V', read & store id
     INV z_pc INV z_nextvar                                  ; move to ->sub
     LDZ z_sub ORZ z_mind DEC FCC var_writesub
     LDZ z_sub
 var_writesub:
-    STT z_nextvar INV z_nextvar                             ; move to ->type
+    SDT z_nextvar INV z_nextvar                             ; move to ->type
     JPS VarCheckDuplicate
-    LDS 3 STT z_nextvar                                     ; write sub (0xff for global) and type
+    LDS 3 SDT z_nextvar                                     ; write sub (0xff for global) and type
 
     ; parse optional [N] buffer size
     MIV 0,z_bufsize                                         ; 0 = no buffer size specified
@@ -2515,30 +2522,30 @@ var_nosize:
     LDI BYTE0(error05) PHS LDI BYTE1(error05) PHS JPA Error    ; error Expecting an int address
 var_typok:
     JPS get SIV 4,z_nextvar
-    LDZ z_A+0 STT z_nextvar INV z_nextvar                      ; vp->ptr
-    LDZ z_A+1 STT z_nextvar INV z_nextvar                      ; z_nextvar at ->max
+    LDZ z_A+0 SDT z_nextvar INV z_nextvar                      ; vp->ptr
+    LDZ z_A+1 SDT z_nextvar INV z_nextvar                      ; z_nextvar at ->max
     ; write ->max: use z_bufsize if [N] specified, else 0xffff
     LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 BNE .abs_sizedmax
     MIT 0xff,z_nextvar INV z_nextvar                           ; vp->max = 0xffff (no [N])
     MIT 0xff,z_nextvar INV z_nextvar
     FPA .abs_maxdone
 .abs_sizedmax:
-    LDZ z_bufsize+0 STT z_nextvar INV z_nextvar                ; vp->max = N
-    LDZ z_bufsize+1 STT z_nextvar INV z_nextvar
+    LDZ z_bufsize+0 SDT z_nextvar INV z_nextvar                ; vp->max = N
+    LDZ z_bufsize+1 SDT z_nextvar INV z_nextvar
 .abs_maxdone:
-    CIT '=',z_pc FEQ .var_absinit
+    CIT '=',z_pc BEQ .var_absinit
     ; no initializer
     LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 FNE .abs_sizednoinit
     FPA var_abselse                                            ; no [N], no = -> original path
 .abs_sizednoinit:
     SIV 6,z_nextvar                                            ; [N] @ addr, no init: cnt = N
-    LDZ z_bufsize+0 STT z_nextvar INV z_nextvar
-    LDZ z_bufsize+1 STT z_nextvar AIV 5,z_nextvar
+    LDZ z_bufsize+0 SDT z_nextvar INV z_nextvar
+    LDZ z_bufsize+1 SDT z_nextvar AIV 5,z_nextvar
     RTS
 .var_absinit:
     INV z_pc                                                   ; consume =
     SIV 7,z_nextvar
-    LDT z_nextvar STZ tcomp_type
+    LDT z_nextvar SDZ tcomp_type
     AIV 7,z_nextvar
     JPS TypedCompExpr
     CIT ',',z_pc FNE .abs_nocomma2                             ; inline check: skip JPS when no comma
@@ -2551,10 +2558,10 @@ var_typok:
     LDZ z_bufsize+0 CPZ z_cnt+0 BCC var_buferr
 .abs_nocheck:
     SIV 6,z_nextvar
-    LDZ z_cnt+0 STT z_nextvar INV z_nextvar
-    LDZ z_cnt+1 STT z_nextvar INV z_nextvar
-    LDT z_nextvar STB var_dst+0 INV z_nextvar
-    LDT z_nextvar STB var_dst+1 AIV 3,z_nextvar
+    LDZ z_cnt+0 SDT z_nextvar INV z_nextvar
+    LDZ z_cnt+1 SDT z_nextvar INV z_nextvar
+    LDT z_nextvar SDB var_dst+0 INV z_nextvar
+    LDT z_nextvar SDB var_dst+1 AIV 3,z_nextvar
     MZB z_sp+0,var_src+0 MZB z_sp+1,var_src+1
     MZZ tcomp_type,z_type
     JPS ScaleCountByType
@@ -2572,15 +2579,15 @@ var_abselse:
     MIT 0,z_nextvar AIV 5,z_nextvar
     RTS
 var_refset:
-    LDZ z_refcnt+0 STT z_nextvar INV z_nextvar
-    LDZ z_refcnt+1 STT z_nextvar AIV 5,z_nextvar
+    LDZ z_refcnt+0 SDT z_nextvar INV z_nextvar
+    LDZ z_refcnt+1 SDT z_nextvar AIV 5,z_nextvar
     RTS
 
     ; === LOCAL-VARIABLE PATH ===
 var_localvar:
     AIV 3,z_nextvar                                          ; move to ->ptr
-    LDZ z_sp+0 STT z_nextvar INV z_nextvar                   ; write z_sp ->ptr
-    LDZ z_sp+1 STT z_nextvar INV z_nextvar                   ; z_nextvar at ->max
+    LDZ z_sp+0 SDT z_nextvar INV z_nextvar                   ; write z_sp ->ptr
+    LDZ z_sp+1 SDT z_nextvar INV z_nextvar                   ; z_nextvar at ->max
     LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 FNE var_localsized
     CIT '=',z_pc BEQ var_localinit
     JPA var_locelse
@@ -2589,10 +2596,10 @@ var_localsized:
     CIT '=',z_pc BEQ var_sizedinit
     ; uninitialized sized buffer: cnt = N, max = N
     SIV 4,z_nextvar                                          ; back to ->cnt
-    LDZ z_bufsize+0 STT z_nextvar INV z_nextvar              ; ->cnt = N
-    LDZ z_bufsize+1 STT z_nextvar AIV 3,z_nextvar            ; skip to ->max
-    LDZ z_bufsize+0 STT z_nextvar INV z_nextvar              ; ->max = N
-    LDZ z_bufsize+1 STT z_nextvar INV z_nextvar
+    LDZ z_bufsize+0 SDT z_nextvar INV z_nextvar              ; ->cnt = N
+    LDZ z_bufsize+1 SDT z_nextvar AIV 3,z_nextvar            ; skip to ->max
+    LDZ z_bufsize+0 SDT z_nextvar INV z_nextvar              ; ->max = N
+    LDZ z_bufsize+1 SDT z_nextvar INV z_nextvar
     MZZ z_bufsize+0,z_cnt+0                                  ; z_cnt = N
     MZZ z_bufsize+1,z_cnt+1
     JPS ScaleCountByType                                     ; z_cnt = N * type
@@ -2604,10 +2611,10 @@ var_localsized:
 var_sizedinit:
     INV z_pc                                                 ; consume =
     ; z_nextvar at ->max; write ->max = N
-    LDZ z_bufsize+0 STT z_nextvar INV z_nextvar
-    LDZ z_bufsize+1 STT z_nextvar INV z_nextvar
+    LDZ z_bufsize+0 SDT z_nextvar INV z_nextvar
+    LDZ z_bufsize+1 SDT z_nextvar INV z_nextvar
     SIV 7,z_nextvar                                          ; back to ->type
-    LDT z_nextvar STZ tcomp_type                             ; read type
+    LDT z_nextvar SDZ tcomp_type                             ; read type
     AIV 7,z_nextvar                                          ; past entry end
     JPS TypedCompExpr
     CIT ',',z_pc FNE .lsznocomma                             ; inline check: skip JPS when no comma
@@ -2619,8 +2626,8 @@ var_sizedinit:
     LDZ z_bufsize+0 CPZ z_cnt+0 BCC var_buferr
 .lszok:
     SIV 6,z_nextvar                                          ; back to ->cnt
-    LDZ z_cnt+0 STT z_nextvar INV z_nextvar                  ; ->cnt = z_cnt
-    LDZ z_cnt+1 STT z_nextvar AIV 5,z_nextvar                ; skip ->ptr, past ->max to next entry
+    LDZ z_cnt+0 SDT z_nextvar INV z_nextvar                  ; ->cnt = z_cnt
+    LDZ z_cnt+1 SDT z_nextvar AIV 5,z_nextvar                ; skip ->ptr, past ->max to next entry
     ; advance sp by N * type (buffer capacity, not element count)
     MZZ z_bufsize+0,z_cnt+0
     MZZ z_bufsize+1,z_cnt+1
@@ -2635,17 +2642,17 @@ var_localinit:
     MIT 0xff,z_nextvar INV z_nextvar                         ; vp->max = 0xffff
     MIT 0xff,z_nextvar INV z_nextvar
     SIV 7,z_nextvar
-    LDT z_nextvar STZ tcomp_type
+    LDT z_nextvar SDZ tcomp_type
     AIV 7,z_nextvar
     JPS TypedCompExpr
     CIT ',',z_pc FNE .loc_nocomma                            ; inline check: skip JPS when no comma
     JPS VarCommaConcat                                       ; handle comma-separated values
 .loc_nocomma:
     SIV 6,z_nextvar
-    LDZ z_cnt+0 STT z_nextvar INV z_nextvar                  ; ->cnt = z_cnt
-    LDZ z_cnt+1 STT z_nextvar AIV 3,z_nextvar                ; move to ->max
-    LDZ z_cnt+0 STT z_nextvar INV z_nextvar                  ; ->max = z_cnt
-    LDZ z_cnt+1 STT z_nextvar INV z_nextvar
+    LDZ z_cnt+0 SDT z_nextvar INV z_nextvar                  ; ->cnt = z_cnt
+    LDZ z_cnt+1 SDT z_nextvar AIV 3,z_nextvar                ; move to ->max
+    LDZ z_cnt+0 SDT z_nextvar INV z_nextvar                  ; ->max = z_cnt
+    LDZ z_cnt+1 SDT z_nextvar INV z_nextvar
     JPS ScaleCountByType                                     ; z_cnt now is z_cnt * z_type
     AVV z_cnt,z_sp
     AVV z_cnt,z_spi
@@ -2677,7 +2684,7 @@ VarCommaConcat:
     JPS CheckZspiTop
     JPS TypedCompExpr                                        ; parse next element (type enforced)
     PLS AD.Z z_cnt+1 PLS ADV z_cnt                           ; accumulate total count
-    PLS STZ z_sp+1 PLS STZ z_sp+0                            ; restore original sp
+    PLS SDZ z_sp+1 PLS SDZ z_sp+0                            ; restore original sp
     MVV z_sp,z_spi INV z_spi
     JPA VarCommaConcat
 .done:
@@ -2694,14 +2701,14 @@ var_buferr:
 ; Raises "Buffer overflow" if cnt >= max.
 AppendStmt:
     JPS ListOpParseVar                          ; facptr = ->type
-    LDT facptr STZ tcomp_type                   ; read variable type for TypedCompExpr
+    LDT facptr SDZ tcomp_type                   ; read variable type for TypedCompExpr
     INV facptr                                  ; ->cnt_lsb
-    LDT facptr STZ z_A+0 INV facptr             ; z_A = cnt
-    LDT facptr STZ z_A+1 INV facptr             ; ->ptr_lsb
-    LDT facptr STZ z_B+0 INV facptr             ; z_B = ptr
-    LDT facptr STZ z_B+1 INV facptr             ; ->max_lsb
-    LDT facptr STZ z_cnt+0 INV facptr           ; z_cnt = max (temp)
-    LDT facptr STZ z_cnt+1
+    LDT facptr SDZ z_A+0 INV facptr             ; z_A = cnt
+    LDT facptr SDZ z_A+1 INV facptr             ; ->ptr_lsb
+    LDT facptr SDZ z_B+0 INV facptr             ; z_B = ptr
+    LDT facptr SDZ z_B+1 INV facptr             ; ->max_lsb
+    LDT facptr SDZ z_cnt+0 INV facptr           ; z_cnt = max (temp)
+    LDT facptr SDZ z_cnt+1
     ; bounds check: cnt < max (z_A < z_cnt)
     LDZ z_A+1 CPZ z_cnt+1 FCC append_ok
     BNE var_buferr                              ; cnt_MSB > max_MSB → overflow
@@ -2723,14 +2730,14 @@ append_ok:
     INV z_pc                                    ; consume comma
     JPS TypedCompExpr                           ; evaluate and type-check value
     ; restore z_sp, cnt, and cnt_ptr
-    PLS STZ z_sp+1 PLS STZ z_sp+0               ; restore z_sp to stack top
+    PLS SDZ z_sp+1 PLS SDZ z_sp+0               ; restore z_sp to stack top
     MVV z_sp,z_spi INV z_spi
-    PLS STZ z_A+1 PLS STZ z_A+0                 ; z_A = old cnt
+    PLS SDZ z_A+1 PLS SDZ z_A+0                 ; z_A = old cnt
     INV z_A                                     ; z_A = cnt + 1
-    PLS STZ facptr+1 PLS STZ facptr+0           ; facptr = ->cnt_lsb
+    PLS SDZ facptr+1 PLS SDZ facptr+0           ; facptr = ->cnt_lsb
     ; write updated cnt back to variable entry
-    LDZ z_A+0 STT facptr INV facptr
-    LDZ z_A+1 STT facptr
+    LDZ z_A+0 SDT facptr INV facptr
+    LDZ z_A+1 SDT facptr
     JPS AssertCRound                            ; consume )
     RTS
 listop_argerr:
@@ -2744,24 +2751,24 @@ ListOpParseVar:
     INV z_pc                                    ; consume V
     LDT z_pc PHS PHS INV z_pc                   ; push var_id, consume
     JPS getVar                                  ; returns ptr to ->type on stack
-    PLS STZ facptr+1 PLS STZ facptr+0           ; pop var ptr into facptr (->type)
+    PLS SDZ facptr+1 PLS SDZ facptr+0           ; pop var ptr into facptr (->type)
     RTS
 
 ; pop(var) — return var[cnt-1], decrement cnt
 fac_pop:
     JPS ListOpParseVar
-    LDT facptr STZ z_type                       ; read variable type
+    LDT facptr SDZ z_type                       ; read variable type
     INV facptr                                  ; ->cnt_lsb
-    LDT facptr STZ z_A+0 INV facptr             ; z_A = cnt
-    LDT facptr STZ z_A+1
+    LDT facptr SDZ z_A+0 INV facptr             ; z_A = cnt
+    LDT facptr SDZ z_A+1
     ; check cnt > 0
     LDZ z_A+0 ORZ z_A+1 CPI 0 BEQ fac_pop_empty
     DEV z_A                                     ; z_A = cnt - 1
     SIV 1,facptr                                ; facptr back to ->cnt_lsb
-    LDZ z_A+0 STT facptr INV facptr             ; write new cnt
-    LDZ z_A+1 STT facptr INV facptr             ; facptr at ->ptr_lsb
-    LDT facptr STZ z_B+0 INV facptr             ; z_B = ptr
-    LDT facptr STZ z_B+1
+    LDZ z_A+0 SDT facptr INV facptr             ; write new cnt
+    LDZ z_A+1 SDT facptr INV facptr             ; facptr at ->ptr_lsb
+    LDT facptr SDZ z_B+0 INV facptr             ; z_B = ptr
+    LDT facptr SDZ z_B+1
     MVV z_A,z_cnt                               ; z_cnt = new cnt
     JPS ScaleCountByType                        ; z_cnt *= type_width
     AVV z_cnt,z_B                               ; z_B = ptr + new_cnt * type_width (source)
@@ -2770,7 +2777,7 @@ fac_pop:
     MZZ z_type,z_cnt+0 CLZ z_cnt+1              ; z_cnt = type_width (1, 2, or 4)
 .pop_copy:
     DEV z_cnt FCC .pop_done
-    LDT z_B STT facptr INV z_B INV facptr
+    LDT z_B SDT facptr INV z_B INV facptr
     FPA .pop_copy
 .pop_done:
     MVV z_sp,z_spi INV z_spi                    ; z_sp unchanged, z_spi = z_sp + 1
@@ -2804,7 +2811,7 @@ VarCheckDuplicate:
     LDZ getptr+0 CPB vardup_end+0 FCC .cmp
     FPA .ok
 .cmp:
-    LDT getptr STZ z_A+0                   ; compare id
+    LDT getptr SDZ z_A+0                   ; compare id
     LDR vardup_new CPZ z_A+0 FNE .next
     INV getptr INW vardup_new              ; compare sub
     LDT getptr CPR vardup_new FNE .restore
@@ -2958,7 +2965,7 @@ TryConstDecl:
     JPS TakeAlNum
     JAS ConstClassifyTypeName
     CPI 0 FEQ .failrestore
-    STB const_decl_type
+    SDB const_decl_type
 .typeok:
     JPS Next
     JPS TakeAlNum CPI 0 FEQ .bad
@@ -3082,7 +3089,7 @@ ConstParseNumericRhs:
 .lit:
     JPS ConstParseNumber CPI 1 FEQ .success
 .failrestore:
-    PLS STZ z_pc+1 PLS STZ z_pc+0
+    PLS SDZ z_pc+1 PLS SDZ z_pc+0
     LDI 0 RTS
 .success:
     PLS PLS
@@ -3128,7 +3135,7 @@ ConstParseStringRhs:
     PLS PLS
     LDI 1 RTS
 .failrestore:
-    PLS STZ z_pc+1 PLS STZ z_pc+0
+    PLS SDZ z_pc+1 PLS SDZ z_pc+0
     LDI 0 RTS
 
 ; parse decimal or 0x hex integer literal into const_data
@@ -3221,7 +3228,7 @@ ParseHexLiteral:
     JPA .done
 .digit:
     SUI '0'
-    FPA .accum
+    JPA .accum
 .upper:
     SUI 55                                                        ; 'A'..'F' -> 10..15
     FPA .accum
@@ -3256,7 +3263,7 @@ ConstCopyName:
     MIW const_name,const_dst
     MIZ 14,z_count
 .loop:
-    LDR const_src STR const_dst INW const_src INW const_dst
+    LDR const_src SDR const_dst INW const_src INW const_dst
     DEZ z_count FNE .loop
     RTS
 
@@ -3300,13 +3307,13 @@ ConstAddEntry:
     MBB const_next+1,const_dst+1
     MIZ 14,z_count
 .cpy:
-    LDR const_src STR const_dst INW const_src INW const_dst
+    LDR const_src SDR const_dst INW const_src INW const_dst
     DEZ z_count BNE .cpy
-    LDB const_num_type STR const_dst INW const_dst
-    LDB const_data+0 STR const_dst INW const_dst
-    LDB const_data+1 STR const_dst INW const_dst
-    LDB const_data+2 STR const_dst INW const_dst
-    LDB const_data+3 STR const_dst INW const_dst
+    LDB const_num_type SDR const_dst INW const_dst
+    LDB const_data+0 SDR const_dst INW const_dst
+    LDB const_data+1 SDR const_dst INW const_dst
+    LDB const_data+2 SDR const_dst INW const_dst
+    LDB const_data+3 SDR const_dst INW const_dst
     MBB const_tmp+0,const_next+0
     MBB const_tmp+1,const_next+1
     RTS
@@ -3319,7 +3326,7 @@ ConstCopyStringBlobToDst:
     MWV const_text_len,z_cnt
 .loop:
     DEV z_cnt FCC .done
-    LDR const_src STR const_dst INW const_src INW const_dst
+    LDR const_src SDR const_dst INW const_src INW const_dst
     INV z_A
     FPA .loop
 .done:
@@ -3337,7 +3344,7 @@ ConstCopyStringLiteralToDst:
     LDT z_pc CPI '"' FEQ .close
     CPI 0 FEQ .bail
     CPI 10 FEQ .bail
-    JPS TakeOrd STR const_dst INW const_dst INV z_A
+    JPS TakeOrd SDR const_dst INW const_dst INV z_A
     FPA .loop
 .close:
     INV z_pc
@@ -3368,7 +3375,7 @@ ConstAddStringEntry:
     MBB consts_next+1,const_dst+1
     MIZ 14,z_count
 .cpyname:
-    LDR const_src STR const_dst INW const_src INW const_dst
+    LDR const_src SDR const_dst INW const_src INW const_dst
     DEZ z_count BNE .cpyname
     MBB const_dst+0,const_scan+0
     MBB const_dst+1,const_scan+1
@@ -3379,8 +3386,8 @@ ConstAddStringEntry:
 .blob:
     JPS ConstCopyStringBlobToDst
 .writelen:
-    LDZ z_A+0 STR const_scan INW const_scan
-    LDZ z_A+1 STR const_scan
+    LDZ z_A+0 SDR const_scan INW const_scan
+    LDZ z_A+1 SDR const_scan
     MBB const_dst+0,consts_next+0
     MBB const_dst+1,consts_next+1
     RTS
@@ -3404,11 +3411,11 @@ ConstLookupNumeric:
     MBB const_scan+0,const_tmp+0
     MBB const_scan+1,const_tmp+1
     AIW 14,const_tmp
-    LDR const_tmp STB const_num_type INW const_tmp
-    LDR const_tmp STB const_data+0 INW const_tmp
-    LDR const_tmp STB const_data+1 INW const_tmp
-    LDR const_tmp STB const_data+2 INW const_tmp
-    LDR const_tmp STB const_data+3
+    LDR const_tmp SDB const_num_type INW const_tmp
+    LDR const_tmp SDB const_data+0 INW const_tmp
+    LDR const_tmp SDB const_data+1 INW const_tmp
+    LDR const_tmp SDB const_data+2 INW const_tmp
+    LDR const_tmp SDB const_data+3
     MIB 1,z_flag
 .nextent:
     AIW const_entry_size,const_scan
@@ -3434,12 +3441,12 @@ ConstLookupString:
     MBB const_src+0,strcmp_b+0
     MBB const_src+1,strcmp_b+1
     MBB const_scan+0,strcmp_a+0 MBB const_scan+1,strcmp_a+1
-    JPS strcmp CPI 0 FNE .loadlen
+    JPS strcmp CPI 0 BNE .loadlen
     MBB const_scan+0,const_tmp+0
     MBB const_scan+1,const_tmp+1
     AIW 14,const_tmp
-    LDR const_tmp STZ z_A+0 INW const_tmp
-    LDR const_tmp STZ z_A+1 INW const_tmp
+    LDR const_tmp SDZ z_A+0 INW const_tmp
+    LDR const_tmp SDZ z_A+1 INW const_tmp
     MZB z_A+0,const_text_len+0
     MZB z_A+1,const_text_len+1
     MBB const_tmp+0,const_text_ptr+0
@@ -3450,8 +3457,8 @@ ConstLookupString:
     MBB const_scan+0,const_tmp+0
     MBB const_scan+1,const_tmp+1
     AIW 14,const_tmp
-    LDR const_tmp STZ z_A+0 INW const_tmp
-    LDR const_tmp STZ z_A+1
+    LDR const_tmp SDZ z_A+0 INW const_tmp
+    LDR const_tmp SDZ z_A+1
 .advance:
     MBB const_scan+0,const_tmp+0
     MBB const_scan+1,const_tmp+1
@@ -3475,15 +3482,15 @@ ConstSubstitute:
     JPS ConstLookupNumeric CPI 1 FNE .fail
     CIB 4,const_num_type FEQ .emitlong
     MIT 0xd0,z_dst INV z_dst
-    LDB const_data+0 STT z_dst INV z_dst
-    LDB const_data+1 STT z_dst INV z_dst
+    LDB const_data+0 SDT z_dst INV z_dst
+    LDB const_data+1 SDT z_dst INV z_dst
     LDI 1 RTS
 .emitlong:
     MIT 0xd1,z_dst INV z_dst
-    LDB const_data+0 STT z_dst INV z_dst
-    LDB const_data+1 STT z_dst INV z_dst
-    LDB const_data+2 STT z_dst INV z_dst
-    LDB const_data+3 STT z_dst INV z_dst
+    LDB const_data+0 SDT z_dst INV z_dst
+    LDB const_data+1 SDT z_dst INV z_dst
+    LDB const_data+2 SDT z_dst INV z_dst
+    LDB const_data+3 SDT z_dst INV z_dst
     LDI 1 RTS
 .fail:
     MIW conststrtab,const_start
@@ -3628,7 +3635,7 @@ linecont:
     CIZ 0,z_halt BEQ SimpleLine                           ; any halt flag set?
     RTS
 lineindent:
-    NOT DEC STZ z_mind INV z_pc RTS
+    NOT DEC SDZ z_mind INV z_pc RTS
 
 ; -------------------------------------------------------------------
 
@@ -3636,7 +3643,7 @@ Block:
     LDZ z_nextvar+0 PHS LDZ z_nextvar+1 PHS   ; save variable and stack state
     LDZ z_sp+0 PHS LDZ z_sp+1 PHS
     LDT z_pc CPI 0xe0 FCC blocksimple         ; is there an indent? => hanging block
-    NOT DEC STZ z_mind INV z_pc               ; consume indentation mark
+    NOT DEC SDZ z_mind INV z_pc               ; consume indentation mark
     INZ z_tind                                ; indentation +1
 blockwhile:
     JPS Statement CIZ 0,z_halt FEQ blockwhile
@@ -3645,11 +3652,11 @@ blocksimple:
     JPS SimpleLine
 blockend:
     LDI 0xfe AN.Z z_halt                      ; clear BLOCKEND flag (bit 0)
-    PLS STZ z_sp+1                            ; restore variable and stack state
-    PLS STZ z_sp+0
+    PLS SDZ z_sp+1                            ; restore variable and stack state
+    PLS SDZ z_sp+0
     MVV z_sp,z_spi
     INV z_spi
-    PLS STZ z_nextvar+1 PLS STZ z_nextvar+0   ; (forget blocks's local variables)
+    PLS SDZ z_nextvar+1 PLS SDZ z_nextvar+0   ; (forget blocks's local variables)
     RTS
 
 ; -------------------------------------------------------------------
@@ -3657,7 +3664,7 @@ blockend:
 ; function block does not need an additional push/pull of variables and math stack
 FastBlock:
     LDT z_pc CPI 0xe0 FCC fblocksimple         ; is there an indent? => hanging block
-    NOT DEC STZ z_mind INV z_pc                ; consume indentation mark
+    NOT DEC SDZ z_mind INV z_pc                ; consume indentation mark
     INZ z_tind                                 ; indentation +1
 fblockwhile:
     JPS Statement CIZ 0,z_halt FEQ fblockwhile
@@ -3678,7 +3685,7 @@ whileloop:
     CPI 0 FEQ whiledone
     JPS Block
     CIZ 0,z_halt FNE whilehalt
-    LDS 1 STZ z_pc+1 LDS 2 STZ z_pc+0
+    LDS 1 SDZ z_pc+1 LDS 2 SDZ z_pc+0
     FPA whileloop
 whiledone:
     PLS PLS
@@ -3720,12 +3727,12 @@ t_blobhex:
     CPI 2 BEQ t_bloboverflow
     CPI 1 BNE t_bloberror
     LDZ z_C+1 ORZ z_C+2 ORZ z_C+3 CPI 0 BNE t_bloboverflow
-    LDZ z_C+0 STT z_dst INV z_dst INV z_cnt
+    LDZ z_C+0 SDT z_dst INV z_dst INV z_cnt
     JPA t_blobloop
 t_blobdone:
     INV z_pc
-    LDZ z_cnt+0 STT z_PtrC INV z_PtrC
-    LDZ z_cnt+1 STT z_PtrC
+    LDZ z_cnt+0 SDT z_PtrC INV z_PtrC
+    LDZ z_cnt+1 SDT z_PtrC
     JPA t_stopcheck
 t_bloboverflow:
     JPA t_hexoverflow
@@ -3734,18 +3741,18 @@ t_bloberror:
 
 skipblob:
     INV z_pc
-    LDT z_pc STZ z_A+0 INV z_pc
-    LDT z_pc STZ z_A+1 INV z_pc
+    LDT z_pc SDZ z_A+0 INV z_pc
+    LDT z_pc SDZ z_A+1 INV z_pc
     AVV z_A,z_pc JPA SkipStmt
 
 fac_blob:
     INV z_pc MIZ 1,z_type
-    LDT z_pc STZ z_cnt+0 STZ z_A+0 INV z_pc
-    LDT z_pc STZ z_cnt+1 STZ z_A+1 INV z_pc
+    LDT z_pc SDZ z_cnt+0 SDZ z_A+0 INV z_pc
+    LDT z_pc SDZ z_cnt+1 SDZ z_A+1 INV z_pc
     MVV z_sp,z_PtrC
 fac_blobloop:
     DEV z_A FCC fac_blobdone
-    LDT z_pc STT z_PtrC INV z_pc INV z_PtrC FPA fac_blobloop
+    LDT z_pc SDT z_PtrC INV z_pc INV z_PtrC FPA fac_blobloop
 fac_blobdone:
     MIT 0,z_PtrC                                            ; write zero-termination byte
     CIB BYTE1(endsp),z_PtrC+1 FCC fac_blobrts
@@ -3888,13 +3895,13 @@ lhs_spill_reserved:
 ;   After push: stack contains [MSB, LSB] (MSB on top)
 ;   Pop order: MSB first, then LSB
 ;   Example: LDZ z_A+0 PHS LDZ z_A+1 PHS  ; push
-;            PLS STZ z_A+1 PLS STZ z_A+0  ; pop
+;            PLS SDZ z_A+1 PLS SDZ z_A+0  ; pop
 ;
 ; 32-bit values: Push byte 0 (LSB), byte 1, byte 2, byte 3 (MSB)
 ;   After push: stack contains [byte3, byte2, byte1, byte0] (byte3 on top)
 ;   Pop order: byte 3, byte 2, byte 1, byte 0
 ;   Example: LDZ z_E+0 PHS LDZ z_E+1 PHS LDZ z_E+2 PHS LDZ z_E+3 PHS  ; push
-;            PLS STZ z_E+3 PLS STZ z_E+2 PLS STZ z_E+1 PLS STZ z_E+0  ; pop
+;            PLS SDZ z_E+3 PLS SDZ z_E+2 PLS SDZ z_E+1 PLS SDZ z_E+0  ; pop
 ; --------------------------------------------------------------------------------------
 
 slice_start: .2byte 0x0000              ; Factor() slice start index temp

--- a/extended-min.min64x4r
+++ b/extended-min.min64x4r
@@ -425,7 +425,7 @@ t_alnumok:
 t_alloop:
     MZB z_itptr+0,strcmp_a+0 MZB z_itptr+1,strcmp_a+1             ; vgl. string @ z_itptr mit string @ z_itnext
     MZB z_itnext+0,strcmp_b+0 MZB z_itnext+1,strcmp_b+1
-    JPS strcmp CPI 0 BEQ t_alentry                                ; found? z_itptr then points to that entry
+    JPS strcmp CPI 0 FEQ t_alentry                                ; found? z_itptr then points to that entry
     AIV 16,z_itptr                                                ; no match => advance to next entry
     CIZ BYTE1(newitems),z_itptr+1 FNE t_alchk                     ; keyword->RAM boundary?
     CIZ BYTE0(newitems),z_itptr+0 FNE t_alchk
@@ -512,7 +512,7 @@ TakeOrd:
     INV z_pc LDT z_pc                               ; look at next character
     CPI 0 BEQ .takeordexit CPI 10 BEQ .takeordexit  ; exit without consuming 0 or \n
 .takeo0:
-    CPI 'r' BNE .takeo1 LDI 13 JPA .takeordret
+    CPI 'r' FNE .takeo1 LDI 13 FPA .takeordret
 .takeo1:
     CPI 'n' FNE .takeo2 LDI 10 FPA .takeordret
 .takeo2:
@@ -707,7 +707,7 @@ PushLongLhsSpill:
     AIW 4,longptr
     CIB BYTE1(lhs_spill_end),longptr+1 BCC .store
     BNE memerror
-    CIB BYTE0(lhs_spill_end),longptr+0 BCC .store
+    CIB BYTE0(lhs_spill_end),longptr+0 FCC .store
     BNE memerror
 .store:
     MVV lhs_spill_ptr,longptr
@@ -1013,10 +1013,10 @@ scalartrue_long:
 
 int_div:
     CLZ z_flag                              ; clear the sign byte
-    CIZ 0,z_A+1 BPL .divanotneg             ; make A and B positive, evaluate the sign of result
+    CIZ 0,z_A+1 FPL .divanotneg             ; make A and B positive, evaluate the sign of result
     INZ z_flag NEV z_A                      ; store a sign, negate A                                    ;
 .divanotneg:
-    CIZ 0,z_B+1 BPL .divbnotneg
+    CIZ 0,z_B+1 FPL .divbnotneg
     INZ z_flag NEV z_B                      ; store a(nother) sign, negate B
 .divbnotneg:
     MZZ z_B+0,z_B+1 CLZ z_B+0               ; move the lower half of B to upper half, clear lower half
@@ -1364,7 +1364,7 @@ fac_passed:
     MVV slice_count,z_A
     MVV slice_count,z_cnt                                   ; z_A = anz, z_cnt = anz
     MVV slice_start,z_B
-    CIZ 1,z_type BEQ fac_elembyte
+    CIZ 1,z_type FEQ fac_elembyte
     JPS ScaleBByType
     JPS ScaleAByType                                        ; scale start/count by element width
 fac_elembyte:
@@ -1673,7 +1673,7 @@ rele_while:
     JPS getB NEV z_B
     PLS AD.Z z_B+1 PLS ADV z_B
     BMI int_true
-    JPA int_false
+    FPA int_false
 rele_lt_rhslong:
     JPS PopIntLhsHiLoToLongE
     JPS getL
@@ -1689,23 +1689,25 @@ rele_lt_lhslong:
     JPA LongCmpLtResult
 int_false:
     CLV z_A JPA rele_reuse
-int_true_pop:
-    PLS JPA int_true
-int_false_pop:
-    PLS JPA int_false
 rele_eq:
     CPI 0xd3 FNE rele_neq
     INV z_pc
     CIZ 4,z_type FEQ rele_eq_lhslong
+    LDZ z_type PHS                                          ; save lhs type: char equality is byte-wise
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_eq_rhslong
     JPS getB
-    PLS CPZ z_B+1 FNE int_false_pop
-    PLS CPZ z_B+0 BNE int_false
+    PLS SDZ z_A+1 PLS SDZ z_A+0 PLS                         ; restore lhs, pop lhs type into A
+    CPI 1 FEQ rele_eq_char                                  ; char on either side -> compare low bytes only
+    CIZ 1,z_type FEQ rele_eq_char
+    LDZ z_A+1 CPZ z_B+1 BNE int_false
+rele_eq_char:
+    LDZ z_A+0 CPZ z_B+0 BNE int_false
     JPA int_true
 rele_eq_rhslong:
     JPS PopIntLhsHiLoToLongE
+    PLS                                                     ; discard saved lhs type
     JPS getL
     JPS LongCompareEC
     JPA LongCmpEqResult
@@ -1721,15 +1723,21 @@ rele_neq:
     CPI 0xd4 FNE rele_leq
     INV z_pc
     CIZ 4,z_type FEQ rele_neq_lhslong
+    LDZ z_type PHS                                          ; save lhs type: char equality is byte-wise
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_neq_rhslong
     JPS getB
-    PLS CPZ z_B+1 BNE int_true_pop
-    PLS CPZ z_B+0 BNE int_true
+    PLS SDZ z_A+1 PLS SDZ z_A+0 PLS                         ; restore lhs, pop lhs type into A
+    CPI 1 FEQ rele_neq_char                                 ; char on either side -> compare low bytes only
+    CIZ 1,z_type FEQ rele_neq_char
+    LDZ z_A+1 CPZ z_B+1 BNE int_true
+rele_neq_char:
+    LDZ z_A+0 CPZ z_B+0 BNE int_true
     JPA int_false
 rele_neq_rhslong:
     JPS PopIntLhsHiLoToLongE
+    PLS                                                     ; discard saved lhs type
     JPS getL
     JPS LongCompareEC
     JPA LongCmpNeResult
@@ -1742,9 +1750,9 @@ rele_neq_lhslong:
     JPS LongCompareEC
     JPA LongCmpNeResult
 rele_leq:
-    CPI 0xd5 FNE rele_geq
+    CPI 0xd5 BNE rele_geq
     INV z_pc
-    CIZ 4,z_type FEQ rele_leq_lhslong
+    CIZ 4,z_type BEQ rele_leq_lhslong
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_leq_rhslong
@@ -1766,9 +1774,9 @@ rele_leq_lhslong:
     JPS LongCompareEC
     JPA LongCmpLeResult
 rele_geq:
-    CPI 0xd6 BNE rele_greater
+    CPI 0xd6 FNE rele_greater
     INV z_pc
-    CIZ 4,z_type BEQ rele_geq_lhslong
+    CIZ 4,z_type FEQ rele_geq_lhslong
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS BaseExpr
     CIZ 4,z_type FEQ rele_geq_rhslong
@@ -1830,7 +1838,7 @@ rele_rts:
 ; handle logical operators: not, and, or, xor, <<, >> (and simultaeously bitwise operators)
 Expr:
     CIT 0xd9,z_pc FEQ expr_not
-    JPS RelExpr FPA expr_while
+    JPS RelExpr JPA expr_while
 expr_not:
     INV z_pc                               ; consume 'not'
     JPS RelExpr
@@ -1838,7 +1846,7 @@ expr_not:
     JPS getL
     JPS LongNotC
     JPS StoreLongResult
-    FPA expr_while
+    JPA expr_while
 expr_not_int:
     JPS get NOV z_A
 expr_reuse:
@@ -1847,26 +1855,26 @@ expr_reuse:
     MIV 1,z_cnt
 expr_while:
     LDT z_pc CPI 0xda BCC expr_rts
-    BNE expr_or
+    FNE expr_or
     INV z_pc
-    CIZ 4,z_type BEQ expr_longand_lhs
+    CIZ 4,z_type FEQ expr_longand_lhs
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS RelExpr
-    CIZ 4,z_type BEQ expr_longand_rhs
+    CIZ 4,z_type FEQ expr_longand_rhs
     JPS get
     PLS AN.Z z_A+1 PLS AN.Z z_A+0
     JPA expr_reuse
 expr_longand_rhs:
     JPS PopIntLhsHiLoToLongE
     JPS LongAndStore
-    JPA expr_while
+    FPA expr_while
 expr_longand_lhs:
     JPS getL
     JPS PushLongLhsSpill
     JPS RelExpr
     JPS PopLongLhsSpill
     JPS LongAndStore
-    JPA expr_while
+    FPA expr_while
 expr_or:
     CPI 0xdb FNE expr_xor
     INV z_pc
@@ -1880,14 +1888,14 @@ expr_or:
 expr_longor_rhs:
     JPS PopIntLhsHiLoToLongE
     JPS LongOrStore
-    JPA expr_while
+    FPA expr_while
 expr_longor_lhs:
     JPS getL
     JPS PushLongLhsSpill
     JPS RelExpr
     JPS PopLongLhsSpill
     JPS LongOrStore
-    JPA expr_while
+    FPA expr_while
 expr_xor:
     CPI 0xdc FNE expr_shiftl
     INV z_pc
@@ -1902,18 +1910,18 @@ expr_xor:
 expr_longxor_rhs:
     JPS PopIntLhsHiLoToLongE
     JPS LongXorStore
-    JPA expr_while
+    FPA expr_while
 expr_longxor_lhs:
     JPS getL
     JPS PushLongLhsSpill
     JPS RelExpr
     JPS PopLongLhsSpill
     JPS LongXorStore
-    JPA expr_while
+    FPA expr_while
 expr_shiftl:
     CPI 0xdd BNE expr_shiftr
     INV z_pc
-    CIZ 4,z_type FEQ expr_longlsl_lhs
+    CIZ 4,z_type BEQ expr_longlsl_lhs
     JPS get LDZ z_A+0 PHS LDZ z_A+1 PHS
     JPS RelExpr
     CIZ 4,z_type FEQ expr_longlsl_rhs
@@ -2013,21 +2021,31 @@ TypedCompExpr:
     MZZ z_type,z_flag                                       ; remember source type before any widening/narrowing
     LDZ tcomp_type CPZ z_type BEQ .tcomp_rts                 ; matching types -> do nothing, else enforce type
     LDZ z_cnt+0 ANI 0xfe ORZ z_cnt+1                        ; conversions are scalar-only
-    CPI 0 BNE .tcomperror
-    CIZ 1,tcomp_type BNE .tcomp_toint                        ; desired type char?
+    CPI 0 FNE .tcomperror
+    CIZ 1,tcomp_type FNE .tcomp_toint                        ; desired type char?
     LDZ z_cnt+0 ANI 0xfe ORZ z_cnt+1                        ; int->char conversion only for one element
-    CPI 0 BNE .tcomperror
-    CIB 4,z_flag BEQ .tcomp_charlong
+    CPI 0 FNE .tcomperror
+    CIB 4,z_flag FEQ .tcomp_charlong
     MVV z_sp,longptr
     INW longptr
     LDR longptr CPI 0 FEQ .tcomp_charintdone
-    PHSPTR error24 JPA Error
+    CPI 0xff FNE .tcomp_charovf                             ; accept -128..-1: hi byte 0xff, lo bit7 set
+    LDT z_sp LL1 FCS .tcomp_chardone                        ; chardone zeroes the byte above the char
+    FPA .tcomp_charovf
 .tcomp_charlong:
-    CIT 0,z_spi FNE .tcomp_charovf
+    CIT 0,z_spi FNE .tcomp_charlongneg
     MVV z_sp,longptr
     AIW 2,longptr
     LDR longptr CPI 0 FNE .tcomp_charovf
     INW longptr LDR longptr CPI 0 FEQ .tcomp_chardone
+    FPA .tcomp_charovf
+.tcomp_charlongneg:
+    CIT 0xff,z_spi FNE .tcomp_charovf                       ; accept -128..-1: bytes 1..3 = 0xff, lo bit7 set
+    MVV z_sp,longptr
+    AIW 2,longptr
+    LDR longptr CPI 0xff FNE .tcomp_charovf
+    INW longptr LDR longptr CPI 0xff FNE .tcomp_charovf
+    LDT z_sp LL1 FCS .tcomp_chardone
 .tcomp_charovf:
     PHSPTR error24 JPA Error
 .tcomp_charintdone:
@@ -2087,19 +2105,19 @@ IfStmt:
 if_1_else:
     JPS SkipStmt
 if_while:
-    CIT 'F',z_pc BNE if_1_end
-    LDZ z_mind CPZ z_tind BNE if_1_end
+    CIT 'F',z_pc FNE if_1_end
+    LDZ z_mind CPZ z_tind FNE if_1_end
     INV z_pc
     LDS 1 CPI 0 FEQ if_2_else
     JPS SkipStmt FPA if_while
 if_2_else:
     JPS Expr JPS ScalarTruthy SDS 1
-    CPI 0 BEQ if_3_else
-    JPS Block JPA if_while
+    CPI 0 FEQ if_3_else
+    JPS Block FPA if_while
 if_3_else:
-    JPS SkipStmt JPA if_while
+    JPS SkipStmt FPA if_while
 if_1_end:
-    CIT 'E',z_pc BNE if_2_end
+    CIT 'E',z_pc FNE if_2_end
     LDZ z_mind CPZ z_tind FNE if_2_end
     INV z_pc
     LDS 1 CPI 0 FEQ if_4_else
@@ -2252,7 +2270,7 @@ fun_isvar:
     LDT z_pc PHS PHS INV z_pc JPS getVar                    ; consume and push ID
     PLS SDZ z_refptr+1 PLS SDZ z_refptr+0                   ; return pointer to ref variable *type*
     SIV 7,z_nextvar                                         ; down to ->type
-    LDT z_refptr CPT z_nextvar FNE fun_typeerr              ; error Reference type mismatch
+    LDT z_refptr CPT z_nextvar BNE fun_typeerr              ; error Reference type mismatch
     INV z_nextvar INV z_refptr                              ; advance to ->cnt
     LDT z_refptr SDT z_nextvar INV z_nextvar INV z_refptr   ; -> cnt
     LDT z_refptr SDT z_nextvar INV z_nextvar INV z_refptr
@@ -2308,9 +2326,9 @@ fun_whileex:
     MVV z_sp,z_spi
     INV z_spi
     PLS SDZ z_nextvar+1 PLS SDZ z_nextvar+0
-    CIZ 0,z_halt FEQ fun_nohalt
+    CIZ 0,z_halt BEQ fun_nohalt
     LDI 0xfb AN.Z z_halt                                    ; clear RETURN flag
-    LDZ z_cnt+0 ORZ z_cnt+1 CPI 0 FEQ fun_rts
+    LDZ z_cnt+0 ORZ z_cnt+1 CPI 0 BEQ fun_rts
     MZB z_sp+0,fun_dst+0                                    ; move return data
     MZB z_sp+1,fun_dst+1
     MZB z_retsp+0,fun_src+0
@@ -2329,9 +2347,9 @@ fun_nohalt:
     CLV z_cnt DEZ call_depth RTS                            ; no 'return' happened
 
 DefStmt:
-    CIT 'S',z_pc BNE deferror
-    CIZ 0,z_sub BNE deferror
-    CIZ 0,z_mind BNE deferror
+    CIT 'S',z_pc FNE deferror
+    CIZ 0,z_sub FNE deferror
+    CIZ 0,z_mind FNE deferror
     INV z_pc                                                ; consume TN_CALL
     LDT z_pc SDT z_nextcall INV z_pc INV z_nextcall         ; consume and store call ID
     JPS AssertORound                                        ; consume (
@@ -2357,7 +2375,7 @@ ass_operator:
     LDS 6 SDZ assptr+0 LDS 5 SDZ assptr+1                   ; vp->type
     LDT assptr SDZ tcomp_type                               ; request typed comp-expr (now z_type = vp->type)
     JPS TypedCompExpr
-    PLS CPI 0xff FEQ ass_nooffset                           ; pull and test offset MSB
+    PLS CPI 0xff BEQ ass_nooffset                           ; pull and test offset MSB
     SDB ass_dst+1 SDZ z_A+1                                 ; offset -> ass_dst, z_A
     PLS SDB ass_dst+0 SDZ z_A+0
     AVV z_cnt,z_A                                           ; RANGE SAFETY-CHECK 1: z_A = z_cnt + offset
@@ -2440,16 +2458,16 @@ ass_nooffa:
     LDT assptr SDZ z_A+0 INV assptr                         ; z_A = ->ptr
     LDT assptr SDZ z_A+1
 ass_offaset:
-    CIZ 1,z_tmp_type FEQ ass_aachar                         ; char path
+    CIZ 1,z_tmp_type BEQ ass_aachar                         ; char path
     CIZ 4,z_tmp_type BEQ ass_aalong                         ; long path
     LDT z_A SDZ z_B+0 INV z_A                               ; int path: load 2 bytes
     LDT z_A SDZ z_B+1
-    CIZ 'a',z_tmp_fastop FNE ass_fsubint
+    CIZ 'a',z_tmp_fastop BNE ass_fsubint
     LDT z_pc ADV z_B INV z_pc                               ; add fast int
     LDT z_pc AD.Z z_B+1 SDT z_A INV z_pc
     DEV z_A LDZ z_B+0 SDT z_A RTS
 ass_fsubint:
-    CIZ 's',z_tmp_fastop BNE ass_error
+    CIZ 's',z_tmp_fastop FNE ass_error
     LDT z_pc SUV z_B INV z_pc                               ; sub fast int
     LDT z_pc SU.Z z_B+1 SDT z_A INV z_pc
     DEV z_A LDZ z_B+0 SDT z_A RTS
@@ -2458,7 +2476,7 @@ ass_aachar:
     LDT z_A ADT z_pc SDT z_A                                ; add fast char
     AIV 2,z_pc RTS
 ass_fsubchar:
-    CIZ 's',z_tmp_fastop BNE ass_error
+    CIZ 's',z_tmp_fastop FNE ass_error
     LDT z_A SUT z_pc SDT z_A                                ; sub fast char
     AIV 2,z_pc RTS
 ass_aalong:
@@ -2525,7 +2543,7 @@ var_typok:
     LDZ z_A+0 SDT z_nextvar INV z_nextvar                      ; vp->ptr
     LDZ z_A+1 SDT z_nextvar INV z_nextvar                      ; z_nextvar at ->max
     ; write ->max: use z_bufsize if [N] specified, else 0xffff
-    LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 BNE .abs_sizedmax
+    LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 FNE .abs_sizedmax
     MIT 0xff,z_nextvar INV z_nextvar                           ; vp->max = 0xffff (no [N])
     MIT 0xff,z_nextvar INV z_nextvar
     FPA .abs_maxdone
@@ -2533,7 +2551,7 @@ var_typok:
     LDZ z_bufsize+0 SDT z_nextvar INV z_nextvar                ; vp->max = N
     LDZ z_bufsize+1 SDT z_nextvar INV z_nextvar
 .abs_maxdone:
-    CIT '=',z_pc BEQ .var_absinit
+    CIT '=',z_pc FEQ .var_absinit
     ; no initializer
     LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 FNE .abs_sizednoinit
     FPA var_abselse                                            ; no [N], no = -> original path
@@ -2589,11 +2607,11 @@ var_localvar:
     LDZ z_sp+0 SDT z_nextvar INV z_nextvar                   ; write z_sp ->ptr
     LDZ z_sp+1 SDT z_nextvar INV z_nextvar                   ; z_nextvar at ->max
     LDZ z_bufsize+0 ORZ z_bufsize+1 CPI 0 FNE var_localsized
-    CIT '=',z_pc BEQ var_localinit
-    JPA var_locelse
+    CIT '=',z_pc FEQ var_localinit
+    FPA var_locelse
 
 var_localsized:
-    CIT '=',z_pc BEQ var_sizedinit
+    CIT '=',z_pc FEQ var_sizedinit
     ; uninitialized sized buffer: cnt = N, max = N
     SIV 4,z_nextvar                                          ; back to ->cnt
     LDZ z_bufsize+0 SDT z_nextvar INV z_nextvar              ; ->cnt = N
@@ -2674,7 +2692,7 @@ var_locelse:
 ; Call after TypedCompExpr when additional comma-separated values may follow.
 ; Accumulates element count into z_cnt; data is laid out consecutively on the stack.
 VarCommaConcat:
-    CIT ',',z_pc BNE .done
+    CIT ',',z_pc FNE .done
     INV z_pc                                                 ; consume comma
     LDZ z_sp+0 PHS LDZ z_sp+1 PHS                            ; save sp
     LDZ z_cnt+0 PHS LDZ z_cnt+1 PHS                          ; save cnt
@@ -2686,7 +2704,7 @@ VarCommaConcat:
     PLS AD.Z z_cnt+1 PLS ADV z_cnt                           ; accumulate total count
     PLS SDZ z_sp+1 PLS SDZ z_sp+0                            ; restore original sp
     MVV z_sp,z_spi INV z_spi
-    JPA VarCommaConcat
+    FPA VarCommaConcat
 .done:
     RTS
 
@@ -2711,8 +2729,8 @@ AppendStmt:
     LDT facptr SDZ z_cnt+1
     ; bounds check: cnt < max (z_A < z_cnt)
     LDZ z_A+1 CPZ z_cnt+1 FCC append_ok
-    BNE var_buferr                              ; cnt_MSB > max_MSB → overflow
-    LDZ z_A+0 CPZ z_cnt+0 BCS var_buferr        ; cnt >= max → overflow
+    FNE var_buferr                              ; cnt_MSB > max_MSB → overflow
+    LDZ z_A+0 CPZ z_cnt+0 FCS var_buferr        ; cnt >= max → overflow
 append_ok:
     SIV 5,facptr                                ; facptr back to ->cnt_lsb
     LDZ facptr+0 PHS LDZ facptr+1 PHS           ; save cnt_ptr on CPU stack
@@ -2762,7 +2780,7 @@ fac_pop:
     LDT facptr SDZ z_A+0 INV facptr             ; z_A = cnt
     LDT facptr SDZ z_A+1
     ; check cnt > 0
-    LDZ z_A+0 ORZ z_A+1 CPI 0 BEQ fac_pop_empty
+    LDZ z_A+0 ORZ z_A+1 CPI 0 FEQ fac_pop_empty
     DEV z_A                                     ; z_A = cnt - 1
     SIV 1,facptr                                ; facptr back to ->cnt_lsb
     LDZ z_A+0 SDT facptr INV facptr             ; write new cnt
@@ -2834,13 +2852,13 @@ vardup_end: .2byte 0xffff                  ; TODO: Consider moving to zero page
 
 Statement:
     LDZ z_mind CPZ z_tind FEQ stmtnormal
-    FMI stmtblockend
+    BMI stmtblockend
     LDI BYTE0(error11) PHS LDI BYTE1(error11) PHS JPA Error ; error unexpected indent
 stmtnormal:
     LDT z_pc CPI 'I' FNE stmtnext1
     INV z_pc JPS IfStmt RTS
 stmtnext1:
-    CPI 'W' FNE stmtnext2
+    CPI 'W' BNE stmtnext2
     INV z_pc JPS WhileStmt RTS
 stmtnext2:
     CPI 'D' FNE stmtsimple
@@ -2874,7 +2892,7 @@ ConstLinePrelude:
 
 ; maintains function-local constant scope by indentation
 ConstScopeState:
-    CIB 0,const_local_active BEQ .wait
+    CIB 0,const_local_active FEQ .wait
     CBB const_fun_indent,ind FCC .wait
     MBB const_local_base+0,const_next+0
     MBB const_local_base+1,const_next+1
@@ -2938,10 +2956,10 @@ ConstClassifyTypeName:
     CPI 0 FEQ .hit
     INW const_src
     INW const_tmp
-    FPA .cmploop
+    JPA .cmploop
 .next:
     AIW 15,const_scan
-    FPA .loop
+    JPA .loop
 .hit:
     MZB z_itnext+0,const_src+0
     MZB z_itnext+1,const_src+1
@@ -2964,11 +2982,11 @@ TryConstDecl:
     MZB z_pc+1,const_savepc+1
     JPS TakeAlNum
     JAS ConstClassifyTypeName
-    CPI 0 FEQ .failrestore
+    CPI 0 BEQ .failrestore
     SDB const_decl_type
 .typeok:
     JPS Next
-    JPS TakeAlNum CPI 0 FEQ .bad
+    JPS TakeAlNum CPI 0 BEQ .bad
     CPI 14 FCC .nameok
     LDI BYTE0(error01) PHS LDI BYTE1(error01) PHS JPA SourceError
 .nameok:
@@ -2981,7 +2999,7 @@ TryConstDecl:
 .sepws1take:
     INV z_pc FPA .sepws1
 .sepc1:
-    CPI ':' FNE .failrestore
+    CPI ':' BNE .failrestore
     INV z_pc
 .sepws2:
     LDT z_pc CPI ' ' FEQ .sepws2take
@@ -2991,33 +3009,33 @@ TryConstDecl:
 .sepws2take:
     INV z_pc FPA .sepws2
 .sepc2:
-    CPI '=' FNE .bad
+    CPI '=' BNE .bad
     INV z_pc
     LDB const_decl_type CPI 1 FNE .int_rhs
 .char_rhs:
     JPS ConstParseNumericRhs CPI 1 FEQ .char_num
-    JPS ConstParseStringRhs CPI 1 FNE .bad
+    JPS ConstParseStringRhs CPI 1 BNE .bad
     FPA .tail
 .char_num:
     CLB const_rhs_type
-    CIB 4,const_num_type FEQ .overflow
+    CIB 4,const_num_type BEQ .overflow
     CIB 0,const_data+1 FEQ .tail
-    FPA .overflow
+    JPA .overflow
 .int_rhs:
-    JPS ConstParseNumericRhs CPI 1 FNE .bad
+    JPS ConstParseNumericRhs CPI 1 BNE .bad
     CLB const_rhs_type
     CIB 4,const_decl_type FNE .int_check
     MIB 4,const_num_type
     FPA .tail
 .int_check:
-    CIB 4,const_num_type FEQ .overflow
+    CIB 4,const_num_type BEQ .overflow
     FPA .tail
 .tail:
     JPS Next
     CPI ';' FNE .tail2
     INV z_pc JPS Next
 .tail2:
-    CPI 10 FEQ .store
+    CPI 10 BEQ .store
     CPI 0 FNE .bad
 .store:
     CIB 0,const_rhs_type FEQ .storenum
@@ -3041,10 +3059,10 @@ ConstParseNumericRhs:
     LDZ z_pc+0 PHS LDZ z_pc+1 PHS
     JPS Next
     CPI '0' FCC .name
-    CPI '9' BLE .lit
+    CPI '9' FLE .lit
 .name:
-    JPS TakeAlNum CPI 0 BEQ .failrestore
-    CPI 14 BCS .failrestore
+    JPS TakeAlNum CPI 0 FEQ .failrestore
+    CPI 14 FCS .failrestore
     JAS ConstClassifyTypeName
     CPI 1 FNE .lookupint
     JPS Next
@@ -3103,14 +3121,14 @@ ConstParseNumericRhs:
 ConstParseStringRhs:
     LDZ z_pc+0 PHS LDZ z_pc+1 PHS
     JPS Next
-    CPI '"' FEQ .literal
-    JPS TakeAlNum CPI 0 BEQ .failrestore
-    CPI 14 BCS .failrestore
+    CPI '"' BEQ .literal
+    JPS TakeAlNum CPI 0 FEQ .failrestore
+    CPI 14 FCS .failrestore
     MZB z_itnext+0,const_src+0
     MZB z_itnext+1,const_src+1
     MIW conststrtab,const_start
-    JPS ConstLookupString CPI 1 BEQ .alias
-    JPA .failrestore
+    JPS ConstLookupString CPI 1 FEQ .alias
+    FPA .failrestore
 .literal:
     MZB z_pc+0,const_text_ptr+0
     MZB z_pc+1,const_text_ptr+1
@@ -3122,7 +3140,7 @@ ConstParseStringRhs:
     CPI 10 FEQ .litbail
     JPS TakeOrd
     INW const_text_len
-    JPA .litloop
+    FPA .litloop
 .litclose:
     INV z_pc
 .litbail:
@@ -3170,8 +3188,8 @@ ConstParseNumber:
 ; overflow:  A=2, z_pc advanced through consumed digits, z_C undefined
 ParseDecimalLiteral32:
     LDT z_pc CPI '0'
-    CPI '0' FCC .not_dec
-    CPI '9' FGT .not_dec
+    CPI '0' BCC .not_dec
+    CPI '9' BGT .not_dec
     CLQ z_C
 .loop:
     MQQ z_C,z_E
@@ -3179,15 +3197,15 @@ ParseDecimalLiteral32:
     LLQ z_C
     LLQ z_C
     LLQ z_C
-    AQQ z_E,z_C FCS .overflow
+    AQQ z_E,z_C BCS .overflow
     LDT z_pc SUI '0' PHS
     PLS AD.Z z_C+0
     LDI 0 AC.Z z_C+1
     LDI 0 AC.Z z_C+2
-    LDI 0 AC.Z z_C+3 FCS .overflow
+    LDI 0 AC.Z z_C+3 BCS .overflow
     INV z_pc
-    LDT z_pc CPI '0' FCC .done
-    CPI '9' FLE .loop
+    LDT z_pc CPI '0' BCC .done
+    CPI '9' BLE .loop
 .done:
     LDI 1 RTS
 .overflow:
@@ -3204,10 +3222,10 @@ ParseDecimalLiteral32:
 ;   - prefix must be lowercase 0x
 ;   - digits may be 0-9, a-f, or A-F
 ParseHexLiteral:
-    CIT '0',z_pc BNE .not_hex
+    CIT '0',z_pc FNE .not_hex
     INV z_pc
     LDT z_pc CPI 'x' FEQ .prefix_ok
-    CPI 'X' BEQ .bad_prefix
+    CPI 'X' FEQ .bad_prefix
     DEV z_pc
     LDI 0 RTS
 .prefix_ok:
@@ -3215,20 +3233,20 @@ ParseHexLiteral:
     CLQ z_C
 .loop:
     LDT z_pc
-    CPI '9' BGT .maybe_upper
-    CPI '0' BCS .digit
-    JPA .done
+    CPI '9' FGT .maybe_upper
+    CPI '0' FCS .digit
+    FPA .done
 .maybe_upper:
     CPI 'F' FGT .maybe_lower
-    CPI 'A' BCS .upper
-    JPA .done
+    CPI 'A' FCS .upper
+    FPA .done
 .maybe_lower:
-    CPI 'f' BGT .done
-    CPI 'a' BCS .lower
-    JPA .done
+    CPI 'f' FGT .done
+    CPI 'a' FCS .lower
+    FPA .done
 .digit:
     SUI '0'
-    JPA .accum
+    FPA .accum
 .upper:
     SUI 55                                                        ; 'A'..'F' -> 10..15
     FPA .accum
@@ -3244,7 +3262,7 @@ ParseHexLiteral:
     LDI 0 AC.Z z_C+1
     LDI 0 AC.Z z_C+2
     LDI 0 AC.Z z_C+3 FCS .overflow
-    INV z_pc JPA .loop
+    INV z_pc FPA .loop
 .done:
     LDI 1 RTS
 .overflow_pop:
@@ -3289,7 +3307,7 @@ ConstNameExists:
 
 ; add constant name at const_name with value in const_data into table
 ConstAddEntry:
-    JPS ConstNameExists CPI 1 FEQ .redef
+    JPS ConstNameExists CPI 1 BEQ .redef
 .nodup:
     MBB const_next+0,const_tmp+0
     MBB const_next+1,const_tmp+1
@@ -3308,7 +3326,7 @@ ConstAddEntry:
     MIZ 14,z_count
 .cpy:
     LDR const_src SDR const_dst INW const_src INW const_dst
-    DEZ z_count BNE .cpy
+    DEZ z_count FNE .cpy
     LDB const_num_type SDR const_dst INW const_dst
     LDB const_data+0 SDR const_dst INW const_dst
     LDB const_data+1 SDR const_dst INW const_dst
@@ -3355,16 +3373,16 @@ ConstCopyStringLiteralToDst:
 
 ; add string constant/alias named const_name with payload in const_text_*
 ConstAddStringEntry:
-    JPS ConstNameExists CPI 1 FEQ .redef
+    JPS ConstNameExists CPI 1 BEQ .redef
     MBB consts_next+0,const_tmp+0
     MBB consts_next+1,const_tmp+1
     AIW const_str_entry_size,const_tmp
     MWV const_text_len,z_A
     LDZ z_A+1 AD.B const_tmp+1
     LDZ z_A+0 ADW const_tmp
-    CIB BYTE1(conststrtab_end),const_tmp+1 BCC .store
+    CIB BYTE1(conststrtab_end),const_tmp+1 FCC .store
     FNE .full
-    CIB BYTE0(conststrtab_end),const_tmp+0 BCC .store
+    CIB BYTE0(conststrtab_end),const_tmp+0 FCC .store
 .full:
     LDI BYTE0(error07) PHS LDI BYTE1(error07) PHS JPA SourceError
 .redef:
@@ -3376,7 +3394,7 @@ ConstAddStringEntry:
     MIZ 14,z_count
 .cpyname:
     LDR const_src SDR const_dst INW const_src INW const_dst
-    DEZ z_count BNE .cpyname
+    DEZ z_count FNE .cpyname
     MBB const_dst+0,const_scan+0
     MBB const_dst+1,const_scan+1
     AIW 2,const_dst
@@ -3400,9 +3418,9 @@ ConstLookupNumeric:
     CLB z_flag
 .loop:
     CBB const_next+1,const_scan+1 FCC .cmp
-    FNE .done
+    BNE .done
     CBB const_next+0,const_scan+0 FCC .cmp
-    FPA .done
+    JPA .done
 .cmp:
     MBB const_src+0,strcmp_b+0
     MBB const_src+1,strcmp_b+1
@@ -3419,7 +3437,7 @@ ConstLookupNumeric:
     MIB 1,z_flag
 .nextent:
     AIW const_entry_size,const_scan
-    FPA .loop
+    JPA .loop
 .done:
     CIZ 1,z_flag FEQ .hit
     LDI 0 RTS
@@ -3433,15 +3451,15 @@ ConstLookupString:
     MBB const_start+1,const_scan+1
     CLB z_flag
 .loop:
-    CBB consts_next+1,const_scan+1 BCC .cmp
-    BNE .done
+    CBB consts_next+1,const_scan+1 FCC .cmp
+    FNE .done
     CBB consts_next+0,const_scan+0 FCC .cmp
-    JPA .done
+    FPA .done
 .cmp:
     MBB const_src+0,strcmp_b+0
     MBB const_src+1,strcmp_b+1
     MBB const_scan+0,strcmp_a+0 MBB const_scan+1,strcmp_a+1
-    JPS strcmp CPI 0 BNE .loadlen
+    JPS strcmp CPI 0 FNE .loadlen
     MBB const_scan+0,const_tmp+0
     MBB const_scan+1,const_tmp+1
     AIW 14,const_tmp
@@ -3467,7 +3485,7 @@ ConstLookupString:
     LDZ z_A+0 ADW const_tmp
     MBB const_tmp+0,const_scan+0
     MBB const_tmp+1,const_scan+1
-    JPA .loop
+    FPA .loop
 .done:
     CIZ 1,z_flag FEQ .hit
     LDI 0 RTS
@@ -3479,7 +3497,7 @@ ConstSubstitute:
     MZB z_itnext+0,const_src+0
     MZB z_itnext+1,const_src+1
     MIW consttab,const_start
-    JPS ConstLookupNumeric CPI 1 FNE .fail
+    JPS ConstLookupNumeric CPI 1 BNE .fail
     CIB 4,const_num_type FEQ .emitlong
     MIT 0xd0,z_dst INV z_dst
     LDB const_data+0 SDT z_dst INV z_dst
@@ -3615,15 +3633,15 @@ linenext6b:
     INV z_pc JPS CallStmt JPA linecont
 linenext7:
     CPI 'P' BNE linenext8
-    INV z_pc JPS PrintStmt JPA linecont
+    INV z_pc JPS PrintStmt FPA linecont
 linenext8:
     CPI 'Q' FNE linenext9
-    INV z_pc JPS SerialStmt JPA linecont
+    INV z_pc JPS SerialStmt FPA linecont
 linenext9:
     CPI 'O' FNE linenext10
-    INV z_pc JPS OutputStmt JPA linecont
+    INV z_pc JPS OutputStmt FPA linecont
 linenext10:
-    CPI 'A' BNE linenext11
+    CPI 'A' FNE linenext11
     INV z_pc JPS AppendStmt FPA linecont
 linenext11:
     CPI 'G' FNE lineerror
@@ -3631,7 +3649,7 @@ linenext11:
 lineerror:
     PHSPTR error02 JPA Error                              ; error invalid simple stmt
 linecont:
-    LDT z_pc CPI 0xe0 BCS lineindent                      ; end of the line (indent) reached?
+    LDT z_pc CPI 0xe0 FCS lineindent                      ; end of the line (indent) reached?
     CIZ 0,z_halt BEQ SimpleLine                           ; any halt flag set?
     RTS
 lineindent:
@@ -3716,19 +3734,19 @@ t_blobstart:
     CLV z_cnt
 t_blobloop:
     JPS Next
-    CPI 10 BNE t_blobnotnl
-    INW g_line INV z_pc JPA t_blobloop
+    CPI 10 FNE t_blobnotnl
+    INW g_line INV z_pc FPA t_blobloop
 t_blobnotnl:
-    CPI ')' BEQ t_blobdone
+    CPI ')' FEQ t_blobdone
     CPI ',' FNE t_blobhex
-    INV z_pc JPA t_blobloop
+    INV z_pc FPA t_blobloop
 t_blobhex:
     JPS ParseHexLiteral
-    CPI 2 BEQ t_bloboverflow
-    CPI 1 BNE t_bloberror
-    LDZ z_C+1 ORZ z_C+2 ORZ z_C+3 CPI 0 BNE t_bloboverflow
+    CPI 2 FEQ t_bloboverflow
+    CPI 1 FNE t_bloberror
+    LDZ z_C+1 ORZ z_C+2 ORZ z_C+3 CPI 0 FNE t_bloboverflow
     LDZ z_C+0 SDT z_dst INV z_dst INV z_cnt
-    JPA t_blobloop
+    FPA t_blobloop
 t_blobdone:
     INV z_pc
     LDZ z_cnt+0 SDT z_PtrC INV z_PtrC

--- a/skills/compile-min-64x4/SKILL.md
+++ b/skills/compile-min-64x4/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: compile-min-64x4
-description: Compile Extended Min Minimal 64x4 assembly with BespokeASM using a repo-local helper that fetches the instruction-set config from GitHub.
+description: Compile Extended Min Minimal 64x4 (and 64x4 Redux) assembly with BespokeASM using a repo-local helper that fetches the instruction-set config from GitHub.
 ---
 
 # Compile Minimal 64x4
 
-Use this skill when you need to compile `*.min64x4` sources in this repository.
+Use this skill when you need to compile `*.min64x4` (Minimal 64x4) or
+`*.min64x4r` (Minimal 64x4 Redux) sources in this repository. The compile
+helper picks the instruction-set config by source extension.
 
 ## Requirements
 
 - `bespokeasm` must be installed and available on `PATH`
 - either `curl` or `wget` must be available so the helper can fetch the Minimal 64x4 BespokeASM config
 
-The helper fetches the Minimal 64x4 config from:
+The helper fetches the configs from:
 
 - `https://raw.githubusercontent.com/michaelkamprath/bespokeasm/main/examples/slu4-minimal-64x4/slu4-minimal-64x4.yaml`
+- `https://raw.githubusercontent.com/michaelkamprath/bespokeasm/main/examples/slu4-minimal-64x4-redux/slu4-minimal-64x4-redux.yaml`
 
 ## Helper Scripts
 
@@ -24,10 +27,16 @@ Fetch the latest Minimal 64x4 config only:
 skills/compile-min-64x4/scripts/fetch_min64x4_config.sh
 ```
 
-Compile a source file:
+Fetch the Minimal 64x4 Redux config only:
 
 ```bash
-skills/compile-min-64x4/scripts/compile_min64x4.sh <source.min64x4>
+skills/compile-min-64x4/scripts/fetch_min64x4_config.sh --redux
+```
+
+Compile a source file (extension selects the config):
+
+```bash
+skills/compile-min-64x4/scripts/compile_min64x4.sh <source.min64x4|source.min64x4r>
 ```
 
 Pass extra BespokeASM args after `--`:
@@ -39,23 +48,27 @@ skills/compile-min-64x4/scripts/compile_min64x4.sh \
 
 The helper:
 
-- uses `fetch_min64x4_config.sh` to fetch the Minimal 64x4 BespokeASM config into `/tmp/slu4-minimal-64x4.yaml`
+- uses `fetch_min64x4_config.sh` to fetch the matching BespokeASM config into
+  `/tmp/slu4-minimal-64x4.yaml` (original) or `/tmp/slu4-minimal-64x4-redux.yaml` (Redux)
 - runs `bespokeasm compile -c <cfg> -n -p`
 - prints the pretty listing to stdout
 
 ## Common Uses
 
-Default build:
+Default builds:
 
 ```bash
 skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4
+skills/compile-min-64x4/scripts/compile_min64x4.sh extended-min.min64x4r
 ```
 
-Accelerator build:
+Accelerator builds:
 
 ```bash
 skills/compile-min-64x4/scripts/compile_min64x4.sh \
   extended-min.min64x4 -- -D USE_ACCELERATOR
+skills/compile-min-64x4/scripts/compile_min64x4.sh \
+  extended-min.min64x4r -- -D USE_ACCELERATOR
 ```
 
 Intel HEX build if needed:
@@ -65,9 +78,20 @@ cfg="$(skills/compile-min-64x4/scripts/fetch_min64x4_config.sh)"
 bespokeasm compile -c "$cfg" -n -p -t intel_hex extended-min.min64x4
 ```
 
+Redux Intel HEX build:
+
+```bash
+cfg="$(skills/compile-min-64x4/scripts/fetch_min64x4_config.sh --redux)"
+bespokeasm compile -c "$cfg" -n -p -t intel_hex extended-min.min64x4r
+```
+
 ## Validation Expectation
 
-For meaningful interpreter changes, compile both:
+For meaningful interpreter changes, compile both build variants of every
+affected target machine:
 
 - default build
 - `USE_ACCELERATOR` build
+
+If a change touches shared interpreter logic, compile both
+`extended-min.min64x4` and `extended-min.min64x4r`.

--- a/skills/compile-min-64x4/scripts/compile_min64x4.sh
+++ b/skills/compile-min-64x4/scripts/compile_min64x4.sh
@@ -3,14 +3,18 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: compile_min64x4.sh <source.min64x4> [-- <extra bespokeasm args>]
+Usage: compile_min64x4.sh <source.min64x4|source.min64x4r> [-- <extra bespokeasm args>]
 
 Compiles a Minimal 64x4 assembly source using BespokeASM and a fetched copy of
-the Minimal 64x4 instruction-set configuration from the BespokeASM GitHub repo.
+the instruction-set configuration from the BespokeASM GitHub repo. Sources
+ending in .min64x4r are compiled against the Minimal 64x4 Redux configuration;
+all other sources use the original Minimal 64x4 configuration.
 
 Examples:
   compile_min64x4.sh extended-min.min64x4
   compile_min64x4.sh extended-min.min64x4 -- -D USE_ACCELERATOR
+  compile_min64x4.sh extended-min.min64x4r
+  compile_min64x4.sh extended-min.min64x4r -- -D USE_ACCELERATOR
 USAGE
 }
 
@@ -50,10 +54,16 @@ if [[ $# -gt 0 ]]; then
   extra_args=("$@")
 fi
 
-cfg="${MIN64X4_CONFIG_PATH:-/tmp/slu4-minimal-64x4.yaml}"
+fetch_args=()
+if [[ "$src" == *.min64x4r ]]; then
+  cfg="${MIN64X4_REDUX_CONFIG_PATH:-/tmp/slu4-minimal-64x4-redux.yaml}"
+  fetch_args=(--redux)
+else
+  cfg="${MIN64X4_CONFIG_PATH:-/tmp/slu4-minimal-64x4.yaml}"
+fi
 
 if [[ ! -s "$cfg" ]]; then
-  "$fetch_script" "$cfg" >/dev/null
+  "$fetch_script" "${fetch_args[@]}" "$cfg" >/dev/null
 fi
 
 if [[ ! -s "$cfg" ]]; then

--- a/skills/compile-min-64x4/scripts/fetch_min64x4_config.sh
+++ b/skills/compile-min-64x4/scripts/fetch_min64x4_config.sh
@@ -3,23 +3,39 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: fetch_min64x4_config.sh [dest]
+Usage: fetch_min64x4_config.sh [--redux] [dest]
 
 Fetches the latest Minimal 64x4 BespokeASM instruction-set configuration file.
 
+Options:
+  --redux Fetch the Minimal 64x4 Redux configuration instead of the original.
+
 Arguments:
   dest    Optional output path. Defaults to MIN64X4_CONFIG_PATH or
-          /tmp/slu4-minimal-64x4.yaml.
+          /tmp/slu4-minimal-64x4.yaml (original), and to
+          MIN64X4_REDUX_CONFIG_PATH or /tmp/slu4-minimal-64x4-redux.yaml
+          (--redux).
 USAGE
 }
+
+variant="original"
+if [[ $# -gt 0 && "$1" == "--redux" ]]; then
+  variant="redux"
+  shift
+fi
 
 if [[ $# -gt 1 ]]; then
   usage >&2
   exit 2
 fi
 
-dest="${1:-${MIN64X4_CONFIG_PATH:-/tmp/slu4-minimal-64x4.yaml}}"
-url="https://raw.githubusercontent.com/michaelkamprath/bespokeasm/main/examples/slu4-minimal-64x4/slu4-minimal-64x4.yaml"
+if [[ "$variant" == "redux" ]]; then
+  dest="${1:-${MIN64X4_REDUX_CONFIG_PATH:-/tmp/slu4-minimal-64x4-redux.yaml}}"
+  url="https://raw.githubusercontent.com/michaelkamprath/bespokeasm/main/examples/slu4-minimal-64x4-redux/slu4-minimal-64x4-redux.yaml"
+else
+  dest="${1:-${MIN64X4_CONFIG_PATH:-/tmp/slu4-minimal-64x4.yaml}}"
+  url="https://raw.githubusercontent.com/michaelkamprath/bespokeasm/main/examples/slu4-minimal-64x4/slu4-minimal-64x4.yaml"
+fi
 
 if command -v curl >/dev/null 2>&1; then
   curl -fsSL -o "$dest" "$url"

--- a/skills/optimize-size/SKILL.md
+++ b/skills/optimize-size/SKILL.md
@@ -5,7 +5,9 @@ description: Optimize Extended Min code size and branch speed by maximizing vali
 
 # Optimize Size (Fast vs Long Branches/Jumps)
 
-Use this skill when modifying `extended-min.min64x4` and you need to recover size/speed after layout drift.
+Use this skill when modifying `extended-min.min64x4` or `extended-min.min64x4r` and you need to recover size/speed after layout drift.
+
+Both targets are supported: the scripts select the ISA config by source extension via `compile_min64x4.sh` (`.min64x4` = original Minimal 64x4, `.min64x4r` = Minimal 64x4 Redux). Optimize each source file separately — the two machines resolve fast-branch page targets differently (instruction address on Redux vs operand fetch address on the original), so their optimal fast/long mixes differ even for line-identical sources.
 
 ## Goal
 

--- a/skills/optimize-size/scripts/optimize_dual.sh
+++ b/skills/optimize-size/scripts/optimize_dual.sh
@@ -3,11 +3,15 @@ set -euo pipefail
 
 usage() {
   cat <<USAGE
-Usage: $0 <source.min64x4> [tag]
+Usage: $0 <source.min64x4 | source.min64x4r> [tag]
 
 Optimizes branch/jump forms for BOTH builds:
   1) default build
   2) build with -D USE_ACCELERATOR
+
+The target ISA is selected by the source extension via compile_min64x4.sh:
+  .min64x4  -> Minimal 64x4 (original)
+  .min64x4r -> Minimal 64x4 Redux
 
 Algorithm:
   - Force all eligible ops to fast/local forms (F*).
@@ -28,7 +32,10 @@ if [[ $# -lt 1 || $# -gt 2 ]]; then
 fi
 
 src="$1"
-tag="${2:-$(basename "${src}" .min64x4)}"
+default_tag="$(basename "${src}")"
+default_tag="${default_tag%.min64x4r}"
+default_tag="${default_tag%.min64x4}"
+tag="${2:-$default_tag}"
 
 if [[ ! -f "$src" ]]; then
   echo "Source not found: $src" >&2

--- a/skills/optimize-size/scripts/run_candidate.sh
+++ b/skills/optimize-size/scripts/run_candidate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<USAGE
-Usage: $0 <source.min64x4> [tag]
+Usage: $0 <source.min64x4 | source.min64x4r> [tag]
 
 Runs full candidate optimization and prints a one-line TSV summary:
   tag  fast  long  align  g_stop_noacc  g_stop_acc  score
@@ -16,7 +16,10 @@ if [[ $# -lt 1 || $# -gt 2 ]]; then
 fi
 
 src="$1"
-tag="${2:-$(basename "${src}" .min64x4)}"
+default_tag="$(basename "${src}")"
+default_tag="${default_tag%.min64x4r}"
+default_tag="${default_tag%.min64x4}"
+tag="${2:-$default_tag}"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/skills/optimize-size/scripts/sweep_string_layout.sh
+++ b/skills/optimize-size/scripts/sweep_string_layout.sh
@@ -128,10 +128,12 @@ move_single_to_tail() {
   rm -f "$out.tmp" "$line_file"
 }
 
-v_baseline="$tmpdir/v_baseline.min64x4"
-v_bigonly="$tmpdir/v_bigonly.min64x4"
-v_big22="$tmpdir/v_big_plus_22.min64x4"
-v_big33="$tmpdir/v_big_plus_33.min64x4"
+# keep the source extension so compile_min64x4.sh selects the right ISA config
+ext="${src##*.}"
+v_baseline="$tmpdir/v_baseline.${ext}"
+v_bigonly="$tmpdir/v_bigonly.${ext}"
+v_big22="$tmpdir/v_big_plus_22.${ext}"
+v_big33="$tmpdir/v_big_plus_33.${ext}"
 
 cp "$src" "$v_baseline"
 make_bigonly "$src" "$v_bigonly"

--- a/tests/arrslice.xmin
+++ b/tests/arrslice.xmin
@@ -2,11 +2,11 @@ int passed = 0
 int failed = 0
 int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0; int t7 = 0; int t8 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -73,9 +73,9 @@ else:
   failed += 1; t8 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6); show_pass(7, t7); show_pass(8, t8)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6); showpass(7, t7); showpass(8, t8)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6); show_fail(7, t7); show_fail(8, t8)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6); showfail(7, t7); showfail(8, t8)
 print("\narrslice PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/buffinit.xmin
+++ b/tests/buffinit.xmin
@@ -213,12 +213,24 @@ char blob[6] = $(
   0xc9, 0x00, 0x22,
   0x7f, 0xe0, 0x0a
 )
+# NOTE: char reads are sign-extended ("C-style"), so 0xe0 compares as -32, not 224.
 if len(blob) == 6:
   if blob[1] == 0:
     if blob[2] == 34:
-      if blob[4] == 224:
+      if blob[4] == -32:
         if blob[5] == 10:
           passed += 1; t18 = 1
+        else:
+          print("blob[5] != 10\n")
+      else:
+        print("blob[4] != -32, blob[4] = ", int(blob[4]), "\n")
+    else:
+      print("blob[2] != 34\n")
+  else:
+    print("blob[1] != 0\n")
+else:
+  print("len(blob) != 6, len = ", len(blob), "\n")
+
 if t18 == 0:
   print("FAIL 18 hex blob init\n")
   failed += 1; t18 = -1
@@ -233,6 +245,8 @@ char rawLongs = $(
   0x78, 0x56, 0x34, 0x12
 )
 long values[1] @ &rawLongs
+# Hex literals > 0xffff tokenize as long constants, so this also regression-tests
+# long hex literal support.
 if words[0] == 0x1234:
   if words[1] == 0x5678:
     if values[0] == 0x12345678:

--- a/tests/buffinit.xmin
+++ b/tests/buffinit.xmin
@@ -213,17 +213,20 @@ char blob[6] = $(
   0xc9, 0x00, 0x22,
   0x7f, 0xe0, 0x0a
 )
-# NOTE: char reads are sign-extended ("C-style"), so 0xe0 compares as -32, not 224.
+# NOTE: char equality is byte-wise, so blob[4] (0xe0) equals both 224 and -32.
 if len(blob) == 6:
   if blob[1] == 0:
     if blob[2] == 34:
-      if blob[4] == -32:
-        if blob[5] == 10:
-          passed += 1; t18 = 1
+      if blob[4] == 224:
+        if blob[4] == -32:
+          if blob[5] == 10:
+            passed += 1; t18 = 1
+          else:
+            print("blob[5] != 10\n")
         else:
-          print("blob[5] != 10\n")
+          print("blob[4] != -32, blob[4] = ", int(blob[4]), "\n")
       else:
-        print("blob[4] != -32, blob[4] = ", int(blob[4]), "\n")
+        print("blob[4] != 224, blob[4] = ", int(blob[4]), "\n")
     else:
       print("blob[2] != 34\n")
   else:

--- a/tests/charsign.xmin
+++ b/tests/charsign.xmin
@@ -1,0 +1,130 @@
+# Char signedness semantics
+# Assignment accepts -128..255; == and != with a char compare low bytes,
+# so extended-ASCII values match in decimal, hex, or negative notation.
+# Ordering, arithmetic, and int() stay signed ("C-style", like slu4 Min).
+
+int passed = 0
+int failed = 0
+int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0; int t7 = 0
+int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0
+
+def showpass(int n, int s):
+  if s == 1:
+    print(n); print(" ")
+
+def showfail(int n, int s):
+  if s == -1:
+    print(n); print(" ")
+
+char blob[4] = $(0xc9, 0x7f, 0xe0, 0x0a)
+
+# Test 1: high-bit byte equals its unsigned decimal value
+if blob[2] == 224:
+  passed += 1; t1 = 1
+else:
+  print("FAIL 1 == 224\n")
+  failed += 1; t1 = -1
+
+# Test 2: same byte equals its hex notation
+if blob[2] == 0xe0:
+  passed += 1; t2 = 1
+else:
+  print("FAIL 2 == 0xe0\n")
+  failed += 1; t2 = -1
+
+# Test 3: same byte equals its signed value
+if blob[2] == -32:
+  passed += 1; t3 = 1
+else:
+  print("FAIL 3 == -32\n")
+  failed += 1; t3 = -1
+
+# Test 4: assign a negative value, read back both ways
+char neg = -32
+if neg == -32:
+  if neg == 224:
+    passed += 1; t4 = 1
+if t4 == 0:
+  print("FAIL 4 char = -32\n")
+  failed += 1; t4 = -1
+
+# Test 5: assign unsigned extended-ASCII, read back both ways
+char pos = 224
+if pos == 224:
+  if pos == -32:
+    passed += 1; t5 = 1
+if t5 == 0:
+  print("FAIL 5 char = 224\n")
+  failed += 1; t5 = -1
+
+# Test 6: != is byte-wise too
+if blob[2] != 225:
+  if blob[2] != -31:
+    passed += 1; t6 = 1
+if t6 == 0:
+  print("FAIL 6 != byte-wise\n")
+  failed += 1; t6 = -1
+
+# Test 7: ordering stays signed: high-bit byte is negative
+if blob[2] < 0:
+  passed += 1; t7 = 1
+else:
+  print("FAIL 7 signed order\n")
+  failed += 1; t7 = -1
+
+# Test 8: sign boundary 0x7f is positive in every notation
+if blob[1] == 127:
+  if blob[1] == 0x7f:
+    if blob[1] > 0:
+      passed += 1; t8 = 1
+if t8 == 0:
+  print("FAIL 8 0x7f boundary\n")
+  failed += 1; t8 = -1
+
+# Test 9: -128 boundary round-trips
+char low = -128
+if low == -128:
+  if low == 128:
+    if low == 0x80:
+      passed += 1; t9 = 1
+if t9 == 0:
+  print("FAIL 9 -128 boundary\n")
+  failed += 1; t9 = -1
+
+# Test 10: 255 boundary round-trips
+char hi = 255
+if hi == 255:
+  if hi == -1:
+    passed += 1; t10 = 1
+if t10 == 0:
+  print("FAIL 10 255 boundary\n")
+  failed += 1; t10 = -1
+
+# Test 11: int() cast is still signed
+if int(blob[2]) == -32:
+  passed += 1; t11 = 1
+else:
+  print("FAIL 11 int() signed\n")
+  failed += 1; t11 = -1
+
+# Test 12: indexed char element assignment accepts negatives
+char buf[3] = 1, 2, 3
+buf[1] = -32
+if buf[1] == 224:
+  if buf[1] == -32:
+    passed += 1; t12 = 1
+if t12 == 0:
+  print("FAIL 12 element = -32\n")
+  failed += 1; t12 = -1
+
+print("PASS ")
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6)
+showpass(7, t7); showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11); showpass(12, t12)
+print("\nFAIL ")
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6)
+showfail(7, t7); showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11); showfail(12, t12)
+print("\ncharsign PASS=")
+print(passed)
+print(" FAIL=")
+print(failed)
+print("\n")

--- a/tests/m1arithm.xmin
+++ b/tests/m1arithm.xmin
@@ -4,11 +4,11 @@ int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0
 int t7 = 0; int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0
 int t13 = 0; int t14 = 0; int t15 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -165,13 +165,13 @@ else:
   failed += 1; t15 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5)
-show_pass(6, t6); show_pass(7, t7); show_pass(8, t8); show_pass(9, t9); show_pass(10, t10)
-show_pass(11, t11); show_pass(12, t12); show_pass(13, t13); show_pass(14, t14); show_pass(15, t15)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5)
+showpass(6, t6); showpass(7, t7); showpass(8, t8); showpass(9, t9); showpass(10, t10)
+showpass(11, t11); showpass(12, t12); showpass(13, t13); showpass(14, t14); showpass(15, t15)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5)
-show_fail(6, t6); show_fail(7, t7); show_fail(8, t8); show_fail(9, t9); show_fail(10, t10)
-show_fail(11, t11); show_fail(12, t12); show_fail(13, t13); show_fail(14, t14); show_fail(15, t15)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5)
+showfail(6, t6); showfail(7, t7); showfail(8, t8); showfail(9, t9); showfail(10, t10)
+showfail(11, t11); showfail(12, t12); showfail(13, t13); showfail(14, t14); showfail(15, t15)
 print("\nm1arithm PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/m1cmpint.xmin
+++ b/tests/m1cmpint.xmin
@@ -4,11 +4,11 @@ int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0
 int t7 = 0; int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0
 int t13 = 0; int t14 = 0; int t15 = 0; int t16 = 0; int t17 = 0; int t18 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -162,13 +162,13 @@ else:
   failed += 1; t18 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6)
-show_pass(7, t7); show_pass(8, t8); show_pass(9, t9); show_pass(10, t10); show_pass(11, t11); show_pass(12, t12)
-show_pass(13, t13); show_pass(14, t14); show_pass(15, t15); show_pass(16, t16); show_pass(17, t17); show_pass(18, t18)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6)
+showpass(7, t7); showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11); showpass(12, t12)
+showpass(13, t13); showpass(14, t14); showpass(15, t15); showpass(16, t16); showpass(17, t17); showpass(18, t18)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6)
-show_fail(7, t7); show_fail(8, t8); show_fail(9, t9); show_fail(10, t10); show_fail(11, t11); show_fail(12, t12)
-show_fail(13, t13); show_fail(14, t14); show_fail(15, t15); show_fail(16, t16); show_fail(17, t17); show_fail(18, t18)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6)
+showfail(7, t7); showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11); showfail(12, t12)
+showfail(13, t13); showfail(14, t14); showfail(15, t15); showfail(16, t16); showfail(17, t17); showfail(18, t18)
 print("\nm1cmpint PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/m1cmplng.xmin
+++ b/tests/m1cmplng.xmin
@@ -5,11 +5,11 @@ int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0; int t13 = 0; int 
 int t15 = 0; int t16 = 0; int t17 = 0; int t18 = 0; int t19 = 0; int t20 = 0; int t21 = 0
 int t22 = 0; int t23 = 0; int t24 = 0; int t25 = 0; int t26 = 0; int t27 = 0; int t28 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -252,15 +252,15 @@ else:
   failed += 1; t28 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6); show_pass(7, t7)
-show_pass(8, t8); show_pass(9, t9); show_pass(10, t10); show_pass(11, t11); show_pass(12, t12); show_pass(13, t13); show_pass(14, t14)
-show_pass(15, t15); show_pass(16, t16); show_pass(17, t17); show_pass(18, t18); show_pass(19, t19); show_pass(20, t20); show_pass(21, t21)
-show_pass(22, t22); show_pass(23, t23); show_pass(24, t24); show_pass(25, t25); show_pass(26, t26); show_pass(27, t27); show_pass(28, t28)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6); showpass(7, t7)
+showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11); showpass(12, t12); showpass(13, t13); showpass(14, t14)
+showpass(15, t15); showpass(16, t16); showpass(17, t17); showpass(18, t18); showpass(19, t19); showpass(20, t20); showpass(21, t21)
+showpass(22, t22); showpass(23, t23); showpass(24, t24); showpass(25, t25); showpass(26, t26); showpass(27, t27); showpass(28, t28)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6); show_fail(7, t7)
-show_fail(8, t8); show_fail(9, t9); show_fail(10, t10); show_fail(11, t11); show_fail(12, t12); show_fail(13, t13); show_fail(14, t14)
-show_fail(15, t15); show_fail(16, t16); show_fail(17, t17); show_fail(18, t18); show_fail(19, t19); show_fail(20, t20); show_fail(21, t21)
-show_fail(22, t22); show_fail(23, t23); show_fail(24, t24); show_fail(25, t25); show_fail(26, t26); show_fail(27, t27); show_fail(28, t28)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6); showfail(7, t7)
+showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11); showfail(12, t12); showfail(13, t13); showfail(14, t14)
+showfail(15, t15); showfail(16, t16); showfail(17, t17); showfail(18, t18); showfail(19, t19); showfail(20, t20); showfail(21, t21)
+showfail(22, t22); showfail(23, t23); showfail(24, t24); showfail(25, t25); showfail(26, t26); showfail(27, t27); showfail(28, t28)
 print("\nm1cmplng PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/m2augasg.xmin
+++ b/tests/m2augasg.xmin
@@ -4,11 +4,11 @@ int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0
 int t7 = 0; int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0
 int t13 = 0; int t14 = 0; int t15 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -169,13 +169,13 @@ else:
   failed += 1; t15 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5)
-show_pass(6, t6); show_pass(7, t7); show_pass(8, t8); show_pass(9, t9); show_pass(10, t10)
-show_pass(11, t11); show_pass(12, t12); show_pass(13, t13); show_pass(14, t14); show_pass(15, t15)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5)
+showpass(6, t6); showpass(7, t7); showpass(8, t8); showpass(9, t9); showpass(10, t10)
+showpass(11, t11); showpass(12, t12); showpass(13, t13); showpass(14, t14); showpass(15, t15)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5)
-show_fail(6, t6); show_fail(7, t7); show_fail(8, t8); show_fail(9, t9); show_fail(10, t10)
-show_fail(11, t11); show_fail(12, t12); show_fail(13, t13); show_fail(14, t14); show_fail(15, t15)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5)
+showfail(6, t6); showfail(7, t7); showfail(8, t8); showfail(9, t9); showfail(10, t10)
+showfail(11, t11); showfail(12, t12); showfail(13, t13); showfail(14, t14); showfail(15, t15)
 print("\nm2augasg PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/m2ctrlfl.xmin
+++ b/tests/m2ctrlfl.xmin
@@ -5,11 +5,11 @@ int t7 = 0; int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0
 int t13 = 0; int t14 = 0; int t15 = 0; int t16 = 0; int t17 = 0; int t18 = 0
 int t19 = 0; int t20 = 0; int t21 = 0; int t22 = 0; int t23 = 0; int t24 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -233,15 +233,15 @@ else:
   passed += 1; t24 = 1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6)
-show_pass(7, t7); show_pass(8, t8); show_pass(9, t9); show_pass(10, t10); show_pass(11, t11); show_pass(12, t12)
-show_pass(13, t13); show_pass(14, t14); show_pass(15, t15); show_pass(16, t16); show_pass(17, t17); show_pass(18, t18)
-show_pass(19, t19); show_pass(20, t20); show_pass(21, t21); show_pass(22, t22); show_pass(23, t23); show_pass(24, t24)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6)
+showpass(7, t7); showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11); showpass(12, t12)
+showpass(13, t13); showpass(14, t14); showpass(15, t15); showpass(16, t16); showpass(17, t17); showpass(18, t18)
+showpass(19, t19); showpass(20, t20); showpass(21, t21); showpass(22, t22); showpass(23, t23); showpass(24, t24)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6)
-show_fail(7, t7); show_fail(8, t8); show_fail(9, t9); show_fail(10, t10); show_fail(11, t11); show_fail(12, t12)
-show_fail(13, t13); show_fail(14, t14); show_fail(15, t15); show_fail(16, t16); show_fail(17, t17); show_fail(18, t18)
-show_fail(19, t19); show_fail(20, t20); show_fail(21, t21); show_fail(22, t22); show_fail(23, t23); show_fail(24, t24)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6)
+showfail(7, t7); showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11); showfail(12, t12)
+showfail(13, t13); showfail(14, t14); showfail(15, t15); showfail(16, t16); showfail(17, t17); showfail(18, t18)
+showfail(19, t19); showfail(20, t20); showfail(21, t21); showfail(22, t22); showfail(23, t23); showfail(24, t24)
 print("\nm2ctrlfl PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/m2varcon.xmin
+++ b/tests/m2varcon.xmin
@@ -4,11 +4,11 @@ int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0; int t7 =
 int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0; int t13 = 0; int t14 = 0
 int t15 = 0; int t16 = 0; int t17 = 0; int t18 = 0; int t19 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -179,13 +179,13 @@ else:
   failed += 1; t19 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6); show_pass(7, t7)
-show_pass(8, t8); show_pass(9, t9); show_pass(10, t10); show_pass(11, t11); show_pass(12, t12); show_pass(13, t13); show_pass(14, t14)
-show_pass(15, t15); show_pass(16, t16); show_pass(17, t17); show_pass(18, t18); show_pass(19, t19)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6); showpass(7, t7)
+showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11); showpass(12, t12); showpass(13, t13); showpass(14, t14)
+showpass(15, t15); showpass(16, t16); showpass(17, t17); showpass(18, t18); showpass(19, t19)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6); show_fail(7, t7)
-show_fail(8, t8); show_fail(9, t9); show_fail(10, t10); show_fail(11, t11); show_fail(12, t12); show_fail(13, t13); show_fail(14, t14)
-show_fail(15, t15); show_fail(16, t16); show_fail(17, t17); show_fail(18, t18); show_fail(19, t19)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6); showfail(7, t7)
+showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11); showfail(12, t12); showfail(13, t13); showfail(14, t14)
+showfail(15, t15); showfail(16, t16); showfail(17, t17); showfail(18, t18); showfail(19, t19)
 print("\nm2varcon PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/p2consts.xmin
+++ b/tests/p2consts.xmin
@@ -4,11 +4,11 @@ int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0
 int t7 = 0; int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0
 int t13 = 0; int t14 = 0; int t15 = 0; int t16 = 0; int t17 = 0; int t18 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -175,13 +175,13 @@ else:
   failed += 1; t18 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6)
-show_pass(7, t7); show_pass(8, t8); show_pass(9, t9); show_pass(10, t10); show_pass(11, t11); show_pass(12, t12)
-show_pass(13, t13); show_pass(14, t14); show_pass(15, t15); show_pass(16, t16); show_pass(17, t17); show_pass(18, t18)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6)
+showpass(7, t7); showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11); showpass(12, t12)
+showpass(13, t13); showpass(14, t14); showpass(15, t15); showpass(16, t16); showpass(17, t17); showpass(18, t18)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6)
-show_fail(7, t7); show_fail(8, t8); show_fail(9, t9); show_fail(10, t10); show_fail(11, t11); show_fail(12, t12)
-show_fail(13, t13); show_fail(14, t14); show_fail(15, t15); show_fail(16, t16); show_fail(17, t17); show_fail(18, t18)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6)
+showfail(7, t7); showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11); showfail(12, t12)
+showfail(13, t13); showfail(14, t14); showfail(15, t15); showfail(16, t16); showfail(17, t17); showfail(18, t18)
 print("\np2consts PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/p4longs1.xmin
+++ b/tests/p4longs1.xmin
@@ -4,11 +4,11 @@ int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0; int t7 =
 int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0; int t13 = 0; int t14 = 0
 int t15 = 0; int t16 = 0; int t17 = 0; int t18 = 0; int t19 = 0; int t20 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -186,13 +186,13 @@ else:
   failed += 1; t20 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6); show_pass(7, t7)
-show_pass(8, t8); show_pass(9, t9); show_pass(10, t10); show_pass(11, t11); show_pass(12, t12); show_pass(13, t13); show_pass(14, t14)
-show_pass(15, t15); show_pass(16, t16); show_pass(17, t17); show_pass(18, t18); show_pass(19, t19); show_pass(20, t20)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6); showpass(7, t7)
+showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11); showpass(12, t12); showpass(13, t13); showpass(14, t14)
+showpass(15, t15); showpass(16, t16); showpass(17, t17); showpass(18, t18); showpass(19, t19); showpass(20, t20)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6); show_fail(7, t7)
-show_fail(8, t8); show_fail(9, t9); show_fail(10, t10); show_fail(11, t11); show_fail(12, t12); show_fail(13, t13); show_fail(14, t14)
-show_fail(15, t15); show_fail(16, t16); show_fail(17, t17); show_fail(18, t18); show_fail(19, t19); show_fail(20, t20)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6); showfail(7, t7)
+showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11); showfail(12, t12); showfail(13, t13); showfail(14, t14)
+showfail(15, t15); showfail(16, t16); showfail(17, t17); showfail(18, t18); showfail(19, t19); showfail(20, t20)
 print("\np4longs1 PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/p5opsctl.xmin
+++ b/tests/p5opsctl.xmin
@@ -3,11 +3,11 @@ int failed = 0
 int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0; int t7 = 0
 int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0; int t12 = 0; int t13 = 0; int t14 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -105,12 +105,12 @@ else:
   print("FAIL 11 long truthy\n")
   failed += 1; t11 = -1
 
-int loop_sum = 0
+int loopsum = 0
 while n >= 1:
-  loop_sum += n
+  loopsum += n
   n = n - 1
 # Test 12: long `while` condition and loop-carried arithmetic.
-if loop_sum == 6:
+if loopsum == 6:
   passed += 1; t12 = 1
 else:
   print("FAIL 12 long while\n")
@@ -149,11 +149,11 @@ else:
   failed += 1; t14 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6); show_pass(7, t7)
-show_pass(8, t8); show_pass(9, t9); show_pass(10, t10); show_pass(11, t11); show_pass(12, t12); show_pass(13, t13); show_pass(14, t14)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6); showpass(7, t7)
+showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11); showpass(12, t12); showpass(13, t13); showpass(14, t14)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6); show_fail(7, t7)
-show_fail(8, t8); show_fail(9, t9); show_fail(10, t10); show_fail(11, t11); show_fail(12, t12); show_fail(13, t13); show_fail(14, t14)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6); showfail(7, t7)
+showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11); showfail(12, t12); showfail(13, t13); showfail(14, t14)
 print("\np5opsctl PASS=")
 print(passed)
 print(" FAIL=")

--- a/tests/p6muldiv.xmin
+++ b/tests/p6muldiv.xmin
@@ -3,11 +3,11 @@ int failed = 0
 int t1 = 0; int t2 = 0; int t3 = 0; int t4 = 0; int t5 = 0; int t6 = 0
 int t7 = 0; int t8 = 0; int t9 = 0; int t10 = 0; int t11 = 0
 
-def show_pass(int n, int s):
+def showpass(int n, int s):
   if s == 1:
     print(n); print(" ")
 
-def show_fail(int n, int s):
+def showfail(int n, int s):
   if s == -1:
     print(n); print(" ")
 
@@ -104,11 +104,11 @@ else:
   failed += 1; t11 = -1
 
 print("PASS ")
-show_pass(1, t1); show_pass(2, t2); show_pass(3, t3); show_pass(4, t4); show_pass(5, t5); show_pass(6, t6)
-show_pass(7, t7); show_pass(8, t8); show_pass(9, t9); show_pass(10, t10); show_pass(11, t11)
+showpass(1, t1); showpass(2, t2); showpass(3, t3); showpass(4, t4); showpass(5, t5); showpass(6, t6)
+showpass(7, t7); showpass(8, t8); showpass(9, t9); showpass(10, t10); showpass(11, t11)
 print("\nFAIL ")
-show_fail(1, t1); show_fail(2, t2); show_fail(3, t3); show_fail(4, t4); show_fail(5, t5); show_fail(6, t6)
-show_fail(7, t7); show_fail(8, t8); show_fail(9, t9); show_fail(10, t10); show_fail(11, t11)
+showfail(1, t1); showfail(2, t2); showfail(3, t3); showfail(4, t4); showfail(5, t5); showfail(6, t6)
+showfail(7, t7); showfail(8, t8); showfail(9, t9); showfail(10, t10); showfail(11, t11)
 print("\np6muldiv PASS=")
 print(passed)
 print(" FAIL=")


### PR DESCRIPTION
## Summary

This PR ports Extended Min to the **Minimal 64x4 Redux** and, along the way, makes
two language improvements that hardware testing surfaced: proper handling of
extended-ASCII `char` values and 32-bit hex literals.

All changes are hardware-validated on both the original Minimal 64x4 and the
Minimal 64x4 Redux.

## Minimal 64x4 Redux port

- New `extended-min.min64x4r`: a 1:1 port of `extended-min.min64x4` to the Redux
  instruction set (`SDZ/SDT/SDB/SDR/SDS` store renames, Redux `#require` pragmas,
  fast-branch form differences). The two sources are kept in sync line-for-line,
  and their compiled instruction streams are verified equivalent in both build
  variants (default and `USE_ACCELERATOR`).
- The `compile-min-64x4` and `optimize-size` skills are now dual-target: the
  source extension selects the ISA config (`.min64x4r` → Redux).
- The release workflow builds and uploads four Intel HEX assets:
  `extended-min`, `extended-min-acc`, `extended-min-redux`, `extended-min-redux-acc`.
- Hardware testing uncovered a bug in the Redux BespokeASM ISA config (missing
  `match_on_argument_bytcode` on `address_lsb`), which let fast branches at page
  boundaries assemble with the wrong target page. Fixed upstream in
  michaelkamprath/bespokeasm; both interpreters here are optimized against the
  corrected config.

## Language changes

**Byte-wise char equality; assignment accepts -128..255.** Chars are frequently
extended-ASCII bytes, and requiring their negative signed form was a footgun.
`==`/`!=` with a `char` operand now compare low bytes, so a stored `0xE0` equals
`224`, `0xe0`, and `-32` alike. Ordering, arithmetic, and `int()` remain signed
("C-style", matching original Min). Backward compatible: every comparison
original Min evaluates as equal stays equal; only comparisons that could never
be true before (chars vs values beyond the signed byte range) can now succeed.

**Long hex literals.** Hex literals wider than 16 bits (e.g. `0x12345678`) now
tokenize as `long` constants instead of silently truncating. Hex `0x0`–`0xffff`
stays an `int` bit pattern so absolute addresses (`@ 0xFE00`) and masks are
unchanged.

## Tests and docs

- New `tests/charsign.xmin` (12 cases: decimal/hex/negative equality, byte-wise
  `!=`, signed ordering, `-128`/`0x7f`/`255` boundaries, `int()`, negative
  element assignment).
- `tests/buffinit.xmin` extended for both char notations and long-hex blob views;
  test suites renamed to EBNF-conformant identifiers (underscore is the
  concatenation operator, not an identifier character).
- README documents char assignment/read/arithmetic semantics and numeric literal
  width rules; ARCHITECTURE.md and AGENTS.md document the dual-target sync rules
  and the fast-branch page behavior.

## Testing

- All four builds compile clean; normalized instruction-stream diff between the
  two interpreter sources shows zero logic differences.
- Full `.xmin` suites pass on real hardware on both machines, including the new
  `charsign.xmin` and the updated `buffinit.xmin`.